### PR TITLE
feat: Add i18n support for all site pages

### DIFF
--- a/src/components/AboutContent.tsx
+++ b/src/components/AboutContent.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from '../i18n/useTranslation';
+
+export default function AboutContent() {
+  const { t, translations } = useTranslation();
+  const about = translations.common.about;
+
+  return (
+    <section className="py-16 px-4">
+      <div className="max-w-3xl mx-auto">
+        {/* Profile */}
+        <div className="text-center mb-12">
+          <div className="w-32 h-32 mx-auto mb-6 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center text-5xl shadow-2xl shadow-primary-500/25">
+            🚀
+          </div>
+          <h1 className="text-4xl font-bold mb-2">Restato</h1>
+          <p className="text-xl text-[var(--color-text-muted)]">
+            {t(about.subtitle)}
+          </p>
+        </div>
+
+        {/* Content */}
+        <div className="prose prose-lg dark:prose-invert max-w-none">
+          <h2>{t(about.greeting)}</h2>
+          <p dangerouslySetInnerHTML={{ __html: t(about.intro) }} />
+
+          <h2>{t(about.whatIsVibeCoding)}</h2>
+          <p dangerouslySetInnerHTML={{ __html: t(about.vibeCodingDesc) }} />
+
+          <h2>{t(about.whatWeCover)}</h2>
+          <ul>
+            <li><strong>{t(about.devLog)}</strong> - {t(about.devLogDesc)}</li>
+            <li><strong>{t(about.til)}</strong> - {t(about.tilDesc)}</li>
+            <li><strong>{t(about.claudeUsage)}</strong> - {t(about.claudeUsageDesc)}</li>
+            <li><strong>{t(about.showcase)}</strong> - {t(about.showcaseDesc)}</li>
+          </ul>
+
+          <h2>{t(about.contact)}</h2>
+          <p>{t(about.contactDesc)}</p>
+        </div>
+
+        {/* Social Links */}
+        <div className="mt-12 flex justify-center gap-4">
+          <a
+            href="https://github.com/restato"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-6 py-3 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+            </svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,13 +1,6 @@
 ---
 import LanguageSelector from './LanguageSelector';
-
-const navItems = [
-  { href: '/', label: 'Home' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/tools', label: 'Tools' },
-  { href: '/projects', label: 'Projects' },
-  { href: '/about', label: 'About' },
-];
+import HeaderNav, { MobileNav } from './HeaderNav';
 
 const currentPath = Astro.url.pathname;
 ---
@@ -24,23 +17,7 @@ const currentPath = Astro.url.pathname;
 
     <!-- Navigation -->
     <div class="flex items-center gap-1">
-      <ul class="hidden sm:flex items-center">
-        {navItems.map((item) => (
-          <li>
-            <a
-              href={item.href}
-              class:list={[
-                'px-4 py-2 rounded-lg text-sm font-medium transition-colors',
-                currentPath === item.href || (item.href !== '/' && currentPath.startsWith(item.href))
-                  ? 'text-primary-600 dark:text-primary-400 bg-primary-500/10'
-                  : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-card-hover)]'
-              ]}
-            >
-              {item.label}
-            </a>
-          </li>
-        ))}
-      </ul>
+      <HeaderNav currentPath={currentPath} client:load />
 
       <!-- Language Selector -->
       <div class="hidden sm:block ml-2">
@@ -79,23 +56,7 @@ const currentPath = Astro.url.pathname;
 
   <!-- Mobile Menu -->
   <div id="mobile-menu" class="hidden sm:hidden border-t border-[var(--color-border)] bg-[var(--color-bg)]">
-    <ul class="px-4 py-3 space-y-1">
-      {navItems.map((item) => (
-        <li>
-          <a
-            href={item.href}
-            class:list={[
-              'block py-2.5 px-4 rounded-lg font-medium transition-colors',
-              currentPath === item.href || (item.href !== '/' && currentPath.startsWith(item.href))
-                ? 'bg-primary-500/10 text-primary-600 dark:text-primary-400'
-                : 'text-[var(--color-text-muted)] hover:bg-[var(--color-card-hover)] hover:text-[var(--color-text)]'
-            ]}
-          >
-            {item.label}
-          </a>
-        </li>
-      ))}
-    </ul>
+    <MobileNav currentPath={currentPath} client:load />
     <!-- Mobile Language Selector -->
     <div class="px-4 pb-3 pt-2 border-t border-[var(--color-border)]">
       <LanguageSelector client:load />

--- a/src/components/HeaderNav.tsx
+++ b/src/components/HeaderNav.tsx
@@ -1,0 +1,69 @@
+import { useTranslation } from '../i18n/useTranslation';
+
+interface HeaderNavProps {
+  currentPath: string;
+}
+
+const navItems = [
+  { href: '/', labelKey: 'home' as const },
+  { href: '/blog', labelKey: 'blog' as const },
+  { href: '/tools', labelKey: 'tools' as const },
+  { href: '/projects', labelKey: 'projects' as const },
+  { href: '/about', labelKey: 'about' as const },
+];
+
+export default function HeaderNav({ currentPath }: HeaderNavProps) {
+  const { t, translations } = useTranslation();
+  const nav = translations.common.nav;
+
+  const isActive = (href: string) => {
+    return currentPath === href || (href !== '/' && currentPath.startsWith(href));
+  };
+
+  return (
+    <ul className="hidden sm:flex items-center">
+      {navItems.map((item) => (
+        <li key={item.href}>
+          <a
+            href={item.href}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              isActive(item.href)
+                ? 'text-primary-600 dark:text-primary-400 bg-primary-500/10'
+                : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-card-hover)]'
+            }`}
+          >
+            {t(nav[item.labelKey])}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function MobileNav({ currentPath }: HeaderNavProps) {
+  const { t, translations } = useTranslation();
+  const nav = translations.common.nav;
+
+  const isActive = (href: string) => {
+    return currentPath === href || (href !== '/' && currentPath.startsWith(href));
+  };
+
+  return (
+    <ul className="px-4 py-3 space-y-1">
+      {navItems.map((item) => (
+        <li key={item.href}>
+          <a
+            href={item.href}
+            className={`block py-2.5 px-4 rounded-lg font-medium transition-colors ${
+              isActive(item.href)
+                ? 'bg-primary-500/10 text-primary-600 dark:text-primary-400'
+                : 'text-[var(--color-text-muted)] hover:bg-[var(--color-card-hover)] hover:text-[var(--color-text)]'
+            }`}
+          >
+            {t(nav[item.labelKey])}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -1,0 +1,256 @@
+import { useTranslation } from '../i18n/useTranslation';
+
+// Hero Section
+export function HeroSection() {
+  const { t, translations } = useTranslation();
+  const idx = translations.common.index;
+  const nav = translations.common.nav;
+
+  return (
+    <section className="py-20 md:py-32 px-6">
+      <div className="max-w-4xl mx-auto">
+        <div className="space-y-8">
+          <div className="space-y-4">
+            <p className="text-sm font-medium text-primary-600 dark:text-primary-400 tracking-wide uppercase">
+              {t(idx.welcome)}
+            </p>
+            <h1 className="text-4xl md:text-6xl font-bold leading-tight">
+              {t(idx.greeting)} <span className="gradient-text">Restato</span>
+            </h1>
+            <p className="text-xl md:text-2xl text-[var(--color-text-muted)] leading-relaxed max-w-2xl">
+              {t(idx.heroDescription)}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-4">
+            <a href="/blog" className="btn btn-primary">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+              </svg>
+              {t(idx.readBlog)}
+            </a>
+            <a href="/projects" className="btn btn-outline">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+              </svg>
+              {t(nav.projects)}
+            </a>
+            <a
+              href="https://github.com/restato"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn btn-ghost text-[var(--color-text-muted)]"
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+              </svg>
+              GitHub
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// Recent Posts Header
+export function RecentPostsHeader() {
+  const { t, translations } = useTranslation();
+  const idx = translations.common.index;
+
+  return (
+    <div className="flex items-end justify-between mb-10">
+      <div>
+        <p className="text-sm font-medium text-primary-600 dark:text-primary-400 mb-2">{t(idx.latestPosts)}</p>
+        <h2 className="text-3xl font-bold">{t(idx.recentPosts)}</h2>
+      </div>
+      <a
+        href="/blog"
+        className="text-sm font-medium text-[var(--color-text-muted)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors flex items-center gap-1"
+      >
+        {t(idx.viewAll)}
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </a>
+    </div>
+  );
+}
+
+// No Posts Message
+export function NoPostsMessage() {
+  const { t, translations } = useTranslation();
+  const idx = translations.common.index;
+
+  return (
+    <div className="text-center py-16 px-6 rounded-2xl border border-dashed border-[var(--color-border)]">
+      <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-primary-500/10 flex items-center justify-center">
+        <svg className="w-8 h-8 text-primary-500" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+        </svg>
+      </div>
+      <p className="text-lg font-medium mb-1">{t(idx.noPosts)}</p>
+      <p className="text-sm text-[var(--color-text-muted)]">{t(idx.comingSoon)}</p>
+    </div>
+  );
+}
+
+// Popular Tools Section
+export function PopularToolsSection() {
+  const { t, translations } = useTranslation();
+  const idx = translations.common.index;
+
+  const tools = [
+    { href: '/tools/json', icon: '{ }', name: idx.jsonFormatter },
+    { href: '/tools/qr-code', icon: '📱', name: idx.qrCode },
+    { href: '/tools/color', icon: '🌈', name: idx.colorConverter },
+    { href: '/tools/image-resizer', icon: '📐', name: idx.imageResizer },
+    { href: '/tools/base64', icon: '🔄', name: idx.base64 },
+    { href: '/tools/utm', icon: '📊', name: idx.utmBuilder },
+    { href: '/tools/regex', icon: '🔍', name: idx.regexTester },
+    { href: '/tools/password', icon: '🔐', name: idx.passwordGenerator },
+  ];
+
+  return (
+    <section className="py-16 px-6 border-t border-[var(--color-border)]">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-end justify-between mb-8">
+          <div>
+            <p className="text-sm font-medium text-primary-600 dark:text-primary-400 mb-2">{t(idx.webTools)}</p>
+            <h2 className="text-3xl font-bold">{t(idx.popularTools)}</h2>
+          </div>
+          <a
+            href="/tools"
+            className="text-sm font-medium text-[var(--color-text-muted)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors flex items-center gap-1"
+          >
+            {t(idx.viewAll)}
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {tools.map((tool) => (
+            <a key={tool.href} href={tool.href} className="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
+              <span className="text-3xl mb-2 block">{tool.icon}</span>
+              <span className="font-medium group-hover:text-primary-500 transition-colors">{t(tool.name)}</span>
+            </a>
+          ))}
+        </div>
+
+        <div className="mt-6 text-center">
+          <a href="/tools" className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-primary-500 text-white font-medium hover:bg-primary-600 transition-colors">
+            26{t(idx.seeAllTools)}
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// Game Center Banner
+export function GameCenterBanner() {
+  const { t, translations } = useTranslation();
+  const idx = translations.common.index;
+
+  return (
+    <section className="py-16 px-6 bg-gradient-to-r from-purple-500/10 via-pink-500/10 to-orange-500/10 border-t border-[var(--color-border)]">
+      <div className="max-w-4xl mx-auto">
+        <a href="/projects/games" className="block group">
+          <div className="flex flex-col md:flex-row items-center gap-8 p-8 bg-[var(--color-card)] rounded-2xl border border-[var(--color-border)] hover:border-primary-500/50 transition-all hover:shadow-xl">
+            <div className="flex gap-2 text-5xl">
+              <span className="animate-bounce" style={{ animationDelay: '0s' }}>🎮</span>
+              <span className="animate-bounce" style={{ animationDelay: '0.1s' }}>🎰</span>
+              <span className="animate-bounce" style={{ animationDelay: '0.2s' }}>🎡</span>
+            </div>
+            <div className="flex-1 text-center md:text-left">
+              <h2 className="text-2xl font-bold mb-2 group-hover:text-primary-500 transition-colors">
+                {t(idx.gameCenterOpen)}
+              </h2>
+              <p className="text-[var(--color-text-muted)] mb-4">
+                {t(idx.gameCenterDesc)}
+              </p>
+              <span className="inline-flex items-center gap-2 text-primary-500 font-medium">
+                {t(idx.playNow)}
+                <svg className="w-4 h-4 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </a>
+      </div>
+    </section>
+  );
+}
+
+// Projects Section
+export function ProjectsSection() {
+  const { t, translations } = useTranslation();
+  const idx = translations.common.index;
+  const nav = translations.common.nav;
+
+  return (
+    <section className="py-20 px-6 bg-[var(--color-card)] border-t border-[var(--color-border)]">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-end justify-between mb-10">
+          <div>
+            <p className="text-sm font-medium text-primary-600 dark:text-primary-400 mb-2">{t(idx.sideProjects)}</p>
+            <h2 className="text-3xl font-bold">{t(nav.projects)}</h2>
+          </div>
+          <a
+            href="/projects"
+            className="text-sm font-medium text-[var(--color-text-muted)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors flex items-center gap-1"
+          >
+            {t(idx.viewAll)}
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </a>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-6">
+          <a href="/projects/games" className="card group bg-gradient-to-br from-purple-500/5 to-pink-500/5 border-primary-500/20">
+            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-2xl mb-4 shadow-lg">
+              🎮
+            </div>
+            <h3 className="text-lg font-bold mb-2 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+              {t(idx.gameCenter)}
+            </h3>
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {t(idx.sixFreeGames)}
+            </p>
+            <span className="inline-block mt-2 text-xs px-2 py-1 bg-primary-500/20 text-primary-500 rounded-full">NEW</span>
+          </a>
+
+          <a href="/projects/roulette" className="card group">
+            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-rose-500 to-orange-500 flex items-center justify-center text-2xl mb-4 shadow-lg">
+              🎡
+            </div>
+            <h3 className="text-lg font-bold mb-2 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+              {t(idx.roulette)}
+            </h3>
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {t(idx.rouletteDesc)}
+            </p>
+          </a>
+
+          <a href="/projects" className="card group border-dashed flex flex-col items-center justify-center text-center min-h-[180px]">
+            <div className="w-12 h-12 rounded-xl bg-[var(--color-card-hover)] flex items-center justify-center mb-4 group-hover:bg-primary-500/10 transition-colors">
+              <svg className="w-6 h-6 text-[var(--color-text-muted)] group-hover:text-primary-500 transition-colors" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+              </svg>
+            </div>
+            <h3 className="text-lg font-bold group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+              {t(idx.seeMore)}
+            </h3>
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/NotFoundContent.tsx
+++ b/src/components/NotFoundContent.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from '../i18n/useTranslation';
+
+export default function NotFoundContent() {
+  const { t, translations } = useTranslation();
+  const notFound = translations.common.notFound;
+
+  return (
+    <section className="py-32 px-4">
+      <div className="max-w-xl mx-auto text-center">
+        <div className="text-8xl mb-8">🔍</div>
+        <h1 className="text-6xl font-bold mb-4">404</h1>
+        <p className="text-xl text-[var(--color-text-muted)] mb-8">
+          {t(notFound.title)}
+        </p>
+        <a
+          href="/"
+          className="btn btn-primary inline-flex items-center gap-2"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          {t(notFound.backHome)}
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectsContent.tsx
+++ b/src/components/ProjectsContent.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from '../i18n/useTranslation';
+
+interface ProjectItem {
+  slug: string;
+  icon: string;
+  titleKey: keyof typeof import('../i18n/translations/common').commonTranslations.projects;
+  descKey: keyof typeof import('../i18n/translations/common').commonTranslations.projects;
+  tags: string[];
+  featured?: boolean;
+}
+
+const builtInProjects: ProjectItem[] = [
+  { slug: 'games', icon: '🎮', titleKey: 'gameCenter', descKey: 'gameCenterDesc', tags: ['Games', 'Interactive', 'Fun'], featured: true },
+  { slug: 'roulette', icon: '🎡', titleKey: 'roulette', descKey: 'rouletteDesc', tags: ['React', 'Animation'] },
+  { slug: 'slot-machine', icon: '🎰', titleKey: 'slotMachine', descKey: 'slotMachineDesc', tags: ['React', 'Game'] },
+  { slug: 'rock-paper-scissors', icon: '✊', titleKey: 'rockPaperScissors', descKey: 'rockPaperScissorsDesc', tags: ['React', 'AI'] },
+  { slug: 'number-guess', icon: '🔢', titleKey: 'numberGuess', descKey: 'numberGuessDesc', tags: ['React', 'Puzzle'] },
+  { slug: 'memory-game', icon: '🧠', titleKey: 'memoryGame', descKey: 'memoryGameDesc', tags: ['React', 'Brain'] },
+  { slug: 'reaction-test', icon: '⚡', titleKey: 'reactionTest', descKey: 'reactionTestDesc', tags: ['React', 'Test'] },
+  { slug: 'gallery', icon: '📷', titleKey: 'gallery', descKey: 'galleryDesc', tags: ['Gallery', 'Lightbox'] },
+];
+
+export function ProjectsHeader() {
+  const { t, translations } = useTranslation();
+  const proj = translations.common.projects;
+
+  return (
+    <div className="mb-12">
+      <h1 className="text-4xl font-bold mb-4">{t(proj.title)}</h1>
+      <p className="text-xl text-[var(--color-text-muted)]">
+        {t(proj.description)}
+      </p>
+    </div>
+  );
+}
+
+export function ProjectsGrid() {
+  const { t, translations } = useTranslation();
+  const proj = translations.common.projects;
+
+  return (
+    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {builtInProjects.map((project) => (
+        <a
+          key={project.slug}
+          href={`/projects/${project.slug}`}
+          className="card group hover:border-primary-500/50"
+        >
+          <div className="text-5xl mb-4">{project.icon}</div>
+          <h3 className="text-xl font-bold mb-2 group-hover:text-primary-500 transition-colors">
+            {t(proj[project.titleKey] as any)}
+          </h3>
+          <p className="text-[var(--color-text-muted)] mb-4">
+            {t(proj[project.descKey] as any)}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {project.tags.map((tag) => (
+              <span key={tag} className="text-xs px-2 py-1 rounded-full bg-[var(--color-border)] text-[var(--color-text-muted)]">
+                {tag}
+              </span>
+            ))}
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export function NewProjectCard() {
+  const { t, translations } = useTranslation();
+  const proj = translations.common.projects;
+
+  return (
+    <div className="card border-dashed flex flex-col items-center justify-center text-center opacity-60 hover:opacity-100 transition-opacity">
+      <div className="text-4xl mb-4">✨</div>
+      <h3 className="text-lg font-bold mb-2">{t(proj.newProject)}</h3>
+      <p className="text-sm text-[var(--color-text-muted)]">
+        {t(proj.comingSoon)}
+      </p>
+    </div>
+  );
+}

--- a/src/i18n/translations/common.ts
+++ b/src/i18n/translations/common.ts
@@ -53,9 +53,28 @@ export const commonTranslations = {
   // Projects page
   projects: {
     title: { ko: '프로젝트', en: 'Projects', ja: 'プロジェクト' },
-    description: { ko: '다양한 프로젝트들을 확인해보세요', en: 'Check out various projects', ja: '様々なプロジェクトをご覧ください' },
+    description: { ko: 'Claude와 함께 만든 다양한 프로젝트들', en: 'Various projects created with Claude', ja: 'Claudeと一緒に作った様々なプロジェクト' },
     viewProject: { ko: '프로젝트 보기', en: 'View Project', ja: 'プロジェクトを見る' },
     allProjects: { ko: '전체 프로젝트', en: 'All Projects', ja: 'すべてのプロジェクト' },
+    newProject: { ko: '새 프로젝트', en: 'New Project', ja: '新しいプロジェクト' },
+    comingSoon: { ko: 'Coming Soon...', en: 'Coming Soon...', ja: 'Coming Soon...' },
+    // Project items
+    gameCenter: { ko: '게임센터', en: 'Game Center', ja: 'ゲームセンター' },
+    gameCenterDesc: { ko: '재미있는 미니게임 모음', en: 'Fun mini game collection', ja: '楽しいミニゲームコレクション' },
+    roulette: { ko: '룰렛', en: 'Roulette', ja: 'ルーレット' },
+    rouletteDesc: { ko: '커스텀 항목으로 돌리는 랜덤 룰렛 게임', en: 'Random roulette game with custom items', ja: 'カスタム項目で回すランダムルーレットゲーム' },
+    slotMachine: { ko: '슬롯머신', en: 'Slot Machine', ja: 'スロットマシン' },
+    slotMachineDesc: { ko: '행운의 777을 노려보세요!', en: 'Try your luck for 777!', ja: 'ラッキー777を狙おう！' },
+    rockPaperScissors: { ko: '가위바위보', en: 'Rock Paper Scissors', ja: 'じゃんけん' },
+    rockPaperScissorsDesc: { ko: 'AI와 대결하는 가위바위보', en: 'Rock paper scissors against AI', ja: 'AIと対決するじゃんけん' },
+    numberGuess: { ko: '숫자 맞추기', en: 'Number Guess', ja: '数字当て' },
+    numberGuessDesc: { ko: 'Up & Down 숫자 맞추기 게임', en: 'Up & Down number guessing game', ja: 'Up & Down数字当てゲーム' },
+    memoryGame: { ko: '기억력 게임', en: 'Memory Game', ja: '記憶力ゲーム' },
+    memoryGameDesc: { ko: '카드 짝 맞추기 두뇌 게임', en: 'Card matching brain game', ja: 'カードマッチング脳トレゲーム' },
+    reactionTest: { ko: '반응속도', en: 'Reaction Test', ja: '反応速度' },
+    reactionTestDesc: { ko: '당신의 반응속도를 측정하세요', en: 'Measure your reaction speed', ja: 'あなたの反応速度を測定' },
+    gallery: { ko: '갤러리', en: 'Gallery', ja: 'ギャラリー' },
+    galleryDesc: { ko: '사진 갤러리', en: 'Photo Gallery', ja: 'フォトギャラリー' },
   },
 
   // Blog
@@ -72,6 +91,79 @@ export const commonTranslations = {
   about: {
     title: { ko: '소개', en: 'About', ja: '紹介' },
     description: { ko: '안녕하세요, 개발자입니다', en: 'Hello, I am a developer', ja: 'こんにちは、開発者です' },
+    subtitle: { ko: 'Developer & Vibe Coder', en: 'Developer & Vibe Coder', ja: 'Developer & Vibe Coder' },
+    greeting: { ko: '안녕하세요! 👋', en: 'Hello! 👋', ja: 'こんにちは！👋' },
+    intro: {
+      ko: 'Claude와 함께 <strong>Vibe Coding</strong>을 하며 다양한 프로젝트를 만들고 있습니다. 이 블로그는 그 과정에서 배운 것들, 만든 것들, 그리고 생각들을 기록하는 공간입니다.',
+      en: "I'm creating various projects with Claude through <strong>Vibe Coding</strong>. This blog is a space to record what I've learned, what I've made, and my thoughts along the way.",
+      ja: 'Claudeと一緒に<strong>Vibe Coding</strong>をしながら様々なプロジェクトを作っています。このブログは、その過程で学んだこと、作ったもの、そして考えを記録する場所です。'
+    },
+    whatIsVibeCoding: { ko: 'Vibe Coding이란?', en: 'What is Vibe Coding?', ja: 'Vibe Codingとは？' },
+    vibeCodingDesc: {
+      ko: 'AI와 함께 코딩하며 아이디어를 빠르게 구현하는 방식입니다. 완벽한 코드보다는 <em>동작하는 것</em>을 우선으로, 배움의 과정 자체를 즐기는 개발 스타일이에요.',
+      en: "It's a way of coding with AI to quickly implement ideas. It's a development style that prioritizes <em>working code</em> over perfect code and enjoys the learning process itself.",
+      ja: 'AIと一緒にコーディングしてアイデアを素早く実装する方式です。完璧なコードよりも<em>動くこと</em>を優先し、学びのプロセス自体を楽しむ開発スタイルです。'
+    },
+    whatWeCover: { ko: '이 블로그에서 다루는 것들', en: 'What We Cover', ja: 'このブログで扱う内容' },
+    devLog: { ko: '개발 일지', en: 'Dev Log', ja: '開発日誌' },
+    devLogDesc: { ko: '프로젝트 진행 과정과 삽질기', en: 'Project progress and troubleshooting', ja: 'プロジェクトの進行過程とトラブルシューティング' },
+    til: { ko: 'TIL', en: 'TIL', ja: 'TIL' },
+    tilDesc: { ko: '오늘 배운 것들', en: 'Today I Learned', ja: '今日学んだこと' },
+    claudeUsage: { ko: 'Claude 활용법', en: 'Claude Usage', ja: 'Claude活用法' },
+    claudeUsageDesc: { ko: 'AI와 효과적으로 협업하는 방법', en: 'How to collaborate effectively with AI', ja: 'AIと効果的に協力する方法' },
+    showcase: { ko: '프로젝트 쇼케이스', en: 'Project Showcase', ja: 'プロジェクトショーケース' },
+    showcaseDesc: { ko: '만든 것들 소개', en: 'Introduction to creations', ja: '作ったものの紹介' },
+    contact: { ko: '연락처', en: 'Contact', ja: '連絡先' },
+    contactDesc: { ko: '궁금한 점이나 피드백이 있으시면 언제든 연락주세요!', en: 'Feel free to reach out if you have questions or feedback!', ja: 'ご質問やフィードバックがあればいつでもご連絡ください！' },
+  },
+
+  // 404 Page
+  notFound: {
+    title: { ko: '페이지를 찾을 수 없습니다', en: 'Page Not Found', ja: 'ページが見つかりません' },
+    description: { ko: '요청하신 페이지가 존재하지 않거나 이동되었습니다.', en: 'The page you requested does not exist or has been moved.', ja: 'リクエストされたページは存在しないか、移動されました。' },
+    backHome: { ko: '홈으로 돌아가기', en: 'Back to Home', ja: 'ホームに戻る' },
+  },
+
+  // Index page
+  index: {
+    welcome: { ko: 'Welcome to my blog', en: 'Welcome to my blog', ja: 'ブログへようこそ' },
+    greeting: { ko: "안녕하세요, 저는", en: "Hi, I'm", ja: 'こんにちは、私は' },
+    heroDescription: {
+      ko: '개발하며 배운 것들을 기록하고, 작은 프로젝트들을 만들어가는 공간입니다.',
+      en: 'A space where I document what I learn while developing and create small projects.',
+      ja: '開発しながら学んだことを記録し、小さなプロジェクトを作っていく場所です。'
+    },
+    readBlog: { ko: '블로그 읽기', en: 'Read Blog', ja: 'ブログを読む' },
+    latestPosts: { ko: 'Latest Posts', en: 'Latest Posts', ja: '最新の投稿' },
+    recentPosts: { ko: '최근 글', en: 'Recent Posts', ja: '最近の投稿' },
+    viewAll: { ko: '전체 보기', en: 'View All', ja: 'すべて見る' },
+    noPosts: { ko: '아직 작성된 글이 없습니다', en: 'No posts yet', ja: 'まだ投稿がありません' },
+    comingSoon: { ko: '곧 첫 번째 글이 올라올 거예요!', en: 'The first post will be up soon!', ja: '最初の投稿がまもなく公開されます！' },
+    webTools: { ko: 'Web Tools', en: 'Web Tools', ja: 'Webツール' },
+    popularTools: { ko: '인기 도구', en: 'Popular Tools', ja: '人気ツール' },
+    seeAllTools: { ko: '개 도구 모두 보기', en: ' tools available', ja: 'つのツールをすべて見る' },
+    gameCenterOpen: { ko: '게임센터 오픈!', en: 'Game Center Open!', ja: 'ゲームセンターオープン！' },
+    gameCenterDesc: {
+      ko: '룰렛, 슬롯머신, 가위바위보, 숫자 맞추기, 기억력 게임, 반응속도 테스트까지! 무료로 즐기는 6가지 미니게임',
+      en: 'Roulette, slot machine, rock-paper-scissors, number guessing, memory game, and reaction test! 6 free mini games to enjoy',
+      ja: 'ルーレット、スロットマシン、じゃんけん、数字当て、記憶力ゲーム、反応速度テストまで！無料で楽しめる6つのミニゲーム'
+    },
+    playNow: { ko: '지금 플레이하기', en: 'Play Now', ja: '今すぐプレイ' },
+    sideProjects: { ko: 'Side Projects', en: 'Side Projects', ja: 'サイドプロジェクト' },
+    gameCenter: { ko: '게임센터', en: 'Game Center', ja: 'ゲームセンター' },
+    sixFreeGames: { ko: '6가지 무료 미니게임', en: '6 Free Mini Games', ja: '6つの無料ミニゲーム' },
+    roulette: { ko: '룰렛', en: 'Roulette', ja: 'ルーレット' },
+    rouletteDesc: { ko: '커스텀 항목으로 돌리는 랜덤 룰렛', en: 'Custom random roulette wheel', ja: 'カスタム項目で回すランダムルーレット' },
+    seeMore: { ko: '더 보기', en: 'See More', ja: 'もっと見る' },
+    // Tool names
+    jsonFormatter: { ko: 'JSON 포매터', en: 'JSON Formatter', ja: 'JSONフォーマッタ' },
+    qrCode: { ko: 'QR 코드', en: 'QR Code', ja: 'QRコード' },
+    colorConverter: { ko: '색상 변환', en: 'Color Converter', ja: '色変換' },
+    imageResizer: { ko: '이미지 리사이저', en: 'Image Resizer', ja: '画像リサイザー' },
+    base64: { ko: 'Base64', en: 'Base64', ja: 'Base64' },
+    utmBuilder: { ko: 'UTM 빌더', en: 'UTM Builder', ja: 'UTMビルダー' },
+    regexTester: { ko: '정규식 테스터', en: 'Regex Tester', ja: '正規表現テスター' },
+    passwordGenerator: { ko: '비밀번호 생성', en: 'Password Generator', ja: 'パスワード生成' },
   },
 
   // Breadcrumb

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,24 +1,8 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import NotFoundContent from '../components/NotFoundContent';
 ---
 
-<MainLayout title="404 - 페이지를 찾을 수 없습니다 | Restato">
-  <section class="py-32 px-4">
-    <div class="max-w-xl mx-auto text-center">
-      <div class="text-8xl mb-8">🔍</div>
-      <h1 class="text-6xl font-bold mb-4">404</h1>
-      <p class="text-xl text-[var(--color-text-muted)] mb-8">
-        페이지를 찾을 수 없습니다
-      </p>
-      <a
-        href="/"
-        class="btn btn-primary inline-flex items-center gap-2"
-      >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-        </svg>
-        홈으로 돌아가기
-      </a>
-    </div>
-  </section>
+<MainLayout title="404 - Page Not Found | Restato">
+  <NotFoundContent client:load />
 </MainLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,64 +1,8 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import AboutContent from '../components/AboutContent';
 ---
 
 <MainLayout title="About | Restato" description="Restato 소개 - Claude와 함께하는 개발 여정">
-  <section class="py-16 px-4">
-    <div class="max-w-3xl mx-auto">
-      <!-- Profile -->
-      <div class="text-center mb-12">
-        <div class="w-32 h-32 mx-auto mb-6 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center text-5xl shadow-2xl shadow-primary-500/25">
-          🚀
-        </div>
-        <h1 class="text-4xl font-bold mb-2">Restato</h1>
-        <p class="text-xl text-[var(--color-text-muted)]">
-          Developer & Vibe Coder
-        </p>
-      </div>
-
-      <!-- Content -->
-      <div class="prose prose-lg dark:prose-invert max-w-none">
-        <h2>안녕하세요! 👋</h2>
-        <p>
-          Claude와 함께 <strong>Vibe Coding</strong>을 하며 다양한 프로젝트를 만들고 있습니다.
-          이 블로그는 그 과정에서 배운 것들, 만든 것들, 그리고 생각들을 기록하는 공간입니다.
-        </p>
-
-        <h2>Vibe Coding이란?</h2>
-        <p>
-          AI와 함께 코딩하며 아이디어를 빠르게 구현하는 방식입니다.
-          완벽한 코드보다는 <em>동작하는 것</em>을 우선으로,
-          배움의 과정 자체를 즐기는 개발 스타일이에요.
-        </p>
-
-        <h2>이 블로그에서 다루는 것들</h2>
-        <ul>
-          <li><strong>개발 일지</strong> - 프로젝트 진행 과정과 삽질기</li>
-          <li><strong>TIL</strong> - 오늘 배운 것들</li>
-          <li><strong>Claude 활용법</strong> - AI와 효과적으로 협업하는 방법</li>
-          <li><strong>프로젝트 쇼케이스</strong> - 만든 것들 소개</li>
-        </ul>
-
-        <h2>연락처</h2>
-        <p>
-          궁금한 점이나 피드백이 있으시면 언제든 연락주세요!
-        </p>
-      </div>
-
-      <!-- Social Links -->
-      <div class="mt-12 flex justify-center gap-4">
-        <a
-          href="https://github.com/restato"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="flex items-center gap-2 px-6 py-3 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
-        >
-          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-          </svg>
-          GitHub
-        </a>
-      </div>
-    </div>
-  </section>
+  <AboutContent client:load />
 </MainLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,14 @@
 import MainLayout from '../layouts/MainLayout.astro';
 import BlogCard from '../components/BlogCard.astro';
 import { getCollection } from 'astro:content';
+import {
+  HeroSection,
+  RecentPostsHeader,
+  NoPostsMessage,
+  PopularToolsSection,
+  GameCenterBanner,
+  ProjectsSection
+} from '../components/HomeContent';
 
 const posts = (await getCollection('blog', ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
@@ -16,68 +24,12 @@ const featuredProjects = projects
 
 <MainLayout title="Restato | Developer Blog">
   <!-- Hero Section -->
-  <section class="py-20 md:py-32 px-6">
-    <div class="max-w-4xl mx-auto">
-      <div class="space-y-8">
-        <div class="space-y-4">
-          <p class="text-sm font-medium text-primary-600 dark:text-primary-400 tracking-wide uppercase">
-            Welcome to my blog
-          </p>
-          <h1 class="text-4xl md:text-6xl font-bold leading-tight">
-            Hi, I'm <span class="gradient-text">Restato</span>
-          </h1>
-          <p class="text-xl md:text-2xl text-[var(--color-text-muted)] leading-relaxed max-w-2xl">
-            개발하며 배운 것들을 기록하고, 작은 프로젝트들을 만들어가는 공간입니다.
-          </p>
-        </div>
-
-        <div class="flex flex-wrap gap-4">
-          <a href="/blog" class="btn btn-primary">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-            </svg>
-            블로그 읽기
-          </a>
-          <a href="/projects" class="btn btn-outline">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-            </svg>
-            프로젝트
-          </a>
-          <a
-            href="https://github.com/restato"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="btn btn-ghost text-[var(--color-text-muted)]"
-          >
-            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-            </svg>
-            GitHub
-          </a>
-        </div>
-      </div>
-    </div>
-  </section>
+  <HeroSection client:load />
 
   <!-- Recent Posts -->
   <section class="py-20 px-6 border-t border-[var(--color-border)]">
     <div class="max-w-4xl mx-auto">
-      <div class="flex items-end justify-between mb-10">
-        <div>
-          <p class="text-sm font-medium text-primary-600 dark:text-primary-400 mb-2">Latest Posts</p>
-          <h2 class="text-3xl font-bold">최근 글</h2>
-        </div>
-        <a
-          href="/blog"
-          class="text-sm font-medium text-[var(--color-text-muted)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors flex items-center gap-1"
-        >
-          전체 보기
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
-        </a>
-      </div>
+      <RecentPostsHeader client:load />
 
       {posts.length > 0 ? (
         <div class="grid md:grid-cols-2 gap-6">
@@ -93,170 +45,17 @@ const featuredProjects = projects
           ))}
         </div>
       ) : (
-        <div class="text-center py-16 px-6 rounded-2xl border border-dashed border-[var(--color-border)]">
-          <div class="w-16 h-16 mx-auto mb-4 rounded-2xl bg-primary-500/10 flex items-center justify-center">
-            <svg class="w-8 h-8 text-primary-500" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
-            </svg>
-          </div>
-          <p class="text-lg font-medium mb-1">아직 작성된 글이 없습니다</p>
-          <p class="text-sm text-[var(--color-text-muted)]">곧 첫 번째 글이 올라올 거예요!</p>
-        </div>
+        <NoPostsMessage client:load />
       )}
     </div>
   </section>
 
   <!-- Popular Tools Section -->
-  <section class="py-16 px-6 border-t border-[var(--color-border)]">
-    <div class="max-w-4xl mx-auto">
-      <div class="flex items-end justify-between mb-8">
-        <div>
-          <p class="text-sm font-medium text-primary-600 dark:text-primary-400 mb-2">Web Tools</p>
-          <h2 class="text-3xl font-bold">인기 도구</h2>
-        </div>
-        <a
-          href="/tools"
-          class="text-sm font-medium text-[var(--color-text-muted)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors flex items-center gap-1"
-        >
-          전체 보기
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
-        </a>
-      </div>
-
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <a href="/tools/json" class="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
-          <span class="text-3xl mb-2 block">{ }</span>
-          <span class="font-medium group-hover:text-primary-500 transition-colors">JSON 포매터</span>
-        </a>
-        <a href="/tools/qr-code" class="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
-          <span class="text-3xl mb-2 block">📱</span>
-          <span class="font-medium group-hover:text-primary-500 transition-colors">QR 코드</span>
-        </a>
-        <a href="/tools/color" class="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
-          <span class="text-3xl mb-2 block">🌈</span>
-          <span class="font-medium group-hover:text-primary-500 transition-colors">색상 변환</span>
-        </a>
-        <a href="/tools/image-resizer" class="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
-          <span class="text-3xl mb-2 block">📐</span>
-          <span class="font-medium group-hover:text-primary-500 transition-colors">이미지 리사이저</span>
-        </a>
-        <a href="/tools/base64" class="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
-          <span class="text-3xl mb-2 block">🔄</span>
-          <span class="font-medium group-hover:text-primary-500 transition-colors">Base64</span>
-        </a>
-        <a href="/tools/utm" class="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
-          <span class="text-3xl mb-2 block">📊</span>
-          <span class="font-medium group-hover:text-primary-500 transition-colors">UTM 빌더</span>
-        </a>
-        <a href="/tools/regex" class="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
-          <span class="text-3xl mb-2 block">🔍</span>
-          <span class="font-medium group-hover:text-primary-500 transition-colors">정규식 테스터</span>
-        </a>
-        <a href="/tools/password" class="group p-4 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)] hover:border-primary-500 hover:shadow-lg transition-all text-center">
-          <span class="text-3xl mb-2 block">🔐</span>
-          <span class="font-medium group-hover:text-primary-500 transition-colors">비밀번호 생성</span>
-        </a>
-      </div>
-
-      <div class="mt-6 text-center">
-        <a href="/tools" class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-primary-500 text-white font-medium hover:bg-primary-600 transition-colors">
-          26개 도구 모두 보기
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
-        </a>
-      </div>
-    </div>
-  </section>
+  <PopularToolsSection client:load />
 
   <!-- Game Center Banner -->
-  <section class="py-16 px-6 bg-gradient-to-r from-purple-500/10 via-pink-500/10 to-orange-500/10 border-t border-[var(--color-border)]">
-    <div class="max-w-4xl mx-auto">
-      <a href="/projects/games" class="block group">
-        <div class="flex flex-col md:flex-row items-center gap-8 p-8 bg-[var(--color-card)] rounded-2xl border border-[var(--color-border)] hover:border-primary-500/50 transition-all hover:shadow-xl">
-          <div class="flex gap-2 text-5xl">
-            <span class="animate-bounce" style="animation-delay: 0s;">🎮</span>
-            <span class="animate-bounce" style="animation-delay: 0.1s;">🎰</span>
-            <span class="animate-bounce" style="animation-delay: 0.2s;">🎡</span>
-          </div>
-          <div class="flex-1 text-center md:text-left">
-            <h2 class="text-2xl font-bold mb-2 group-hover:text-primary-500 transition-colors">
-              게임센터 오픈!
-            </h2>
-            <p class="text-[var(--color-text-muted)] mb-4">
-              룰렛, 슬롯머신, 가위바위보, 숫자 맞추기, 기억력 게임, 반응속도 테스트까지!
-              무료로 즐기는 6가지 미니게임
-            </p>
-            <span class="inline-flex items-center gap-2 text-primary-500 font-medium">
-              지금 플레이하기
-              <svg class="w-4 h-4 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </span>
-          </div>
-        </div>
-      </a>
-    </div>
-  </section>
+  <GameCenterBanner client:load />
 
   <!-- Projects Section -->
-  <section class="py-20 px-6 bg-[var(--color-card)] border-t border-[var(--color-border)]">
-    <div class="max-w-4xl mx-auto">
-      <div class="flex items-end justify-between mb-10">
-        <div>
-          <p class="text-sm font-medium text-primary-600 dark:text-primary-400 mb-2">Side Projects</p>
-          <h2 class="text-3xl font-bold">프로젝트</h2>
-        </div>
-        <a
-          href="/projects"
-          class="text-sm font-medium text-[var(--color-text-muted)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors flex items-center gap-1"
-        >
-          전체 보기
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
-        </a>
-      </div>
-
-      <div class="grid md:grid-cols-3 gap-6">
-        <a href="/projects/games" class="card group bg-gradient-to-br from-purple-500/5 to-pink-500/5 border-primary-500/20">
-          <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center text-2xl mb-4 shadow-lg">
-            🎮
-          </div>
-          <h3 class="text-lg font-bold mb-2 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
-            게임센터
-          </h3>
-          <p class="text-sm text-[var(--color-text-muted)]">
-            6가지 무료 미니게임
-          </p>
-          <span class="inline-block mt-2 text-xs px-2 py-1 bg-primary-500/20 text-primary-500 rounded-full">NEW</span>
-        </a>
-
-        <a href="/projects/roulette" class="card group">
-          <div class="w-12 h-12 rounded-xl bg-gradient-to-br from-rose-500 to-orange-500 flex items-center justify-center text-2xl mb-4 shadow-lg">
-            🎡
-          </div>
-          <h3 class="text-lg font-bold mb-2 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
-            룰렛
-          </h3>
-          <p class="text-sm text-[var(--color-text-muted)]">
-            커스텀 항목으로 돌리는 랜덤 룰렛
-          </p>
-        </a>
-
-        <a href="/projects" class="card group border-dashed flex flex-col items-center justify-center text-center min-h-[180px]">
-          <div class="w-12 h-12 rounded-xl bg-[var(--color-card-hover)] flex items-center justify-center mb-4 group-hover:bg-primary-500/10 transition-colors">
-            <svg class="w-6 h-6 text-[var(--color-text-muted)] group-hover:text-primary-500 transition-colors" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-            </svg>
-          </div>
-          <h3 class="text-lg font-bold group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
-            더 보기
-          </h3>
-        </a>
-      </div>
-    </div>
-  </section>
+  <ProjectsSection client:load />
 </MainLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,106 +1,21 @@
 ---
 import MainLayout from '../../layouts/MainLayout.astro';
 import { getCollection } from 'astro:content';
+import { ProjectsHeader, ProjectsGrid, NewProjectCard } from '../../components/ProjectsContent';
 
 const projects = (await getCollection('projects'))
   .sort((a, b) => a.data.order - b.data.order);
-
-// Hardcoded projects for now (can be moved to content collection later)
-const builtInProjects = [
-  {
-    slug: 'games',
-    title: '게임센터',
-    description: '재미있는 미니게임 모음',
-    icon: '🎮',
-    tags: ['Games', 'Interactive', 'Fun'],
-    featured: true,
-  },
-  {
-    slug: 'roulette',
-    title: '룰렛',
-    description: '커스텀 항목으로 돌리는 랜덤 룰렛 게임',
-    icon: '🎡',
-    tags: ['React', 'Animation'],
-  },
-  {
-    slug: 'slot-machine',
-    title: '슬롯머신',
-    description: '행운의 777을 노려보세요!',
-    icon: '🎰',
-    tags: ['React', 'Game'],
-  },
-  {
-    slug: 'rock-paper-scissors',
-    title: '가위바위보',
-    description: 'AI와 대결하는 가위바위보',
-    icon: '✊',
-    tags: ['React', 'AI'],
-  },
-  {
-    slug: 'number-guess',
-    title: '숫자 맞추기',
-    description: 'Up & Down 숫자 맞추기 게임',
-    icon: '🔢',
-    tags: ['React', 'Puzzle'],
-  },
-  {
-    slug: 'memory-game',
-    title: '기억력 게임',
-    description: '카드 짝 맞추기 두뇌 게임',
-    icon: '🧠',
-    tags: ['React', 'Brain'],
-  },
-  {
-    slug: 'reaction-test',
-    title: '반응속도',
-    description: '당신의 반응속도를 측정하세요',
-    icon: '⚡',
-    tags: ['React', 'Test'],
-  },
-  {
-    slug: 'gallery',
-    title: '갤러리',
-    description: '사진 갤러리',
-    icon: '📷',
-    tags: ['Gallery', 'Lightbox'],
-  },
-];
 ---
 
 <MainLayout title="프로젝트 | Restato" description="Claude와 함께 만든 프로젝트들">
   <section class="py-16 px-4">
     <div class="max-w-5xl mx-auto">
       <!-- Header -->
-      <div class="mb-12">
-        <h1 class="text-4xl font-bold mb-4">프로젝트</h1>
-        <p class="text-xl text-[var(--color-text-muted)]">
-          Claude와 함께 만든 다양한 프로젝트들
-        </p>
-      </div>
+      <ProjectsHeader client:load />
 
       <!-- Projects Grid -->
       <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {builtInProjects.map((project) => (
-          <a
-            href={`/projects/${project.slug}`}
-            class="card group hover:border-primary-500/50"
-          >
-            <div class="text-5xl mb-4">{project.icon}</div>
-            <h3 class="text-xl font-bold mb-2 group-hover:text-primary-500 transition-colors">
-              {project.title}
-            </h3>
-            <p class="text-[var(--color-text-muted)] mb-4">
-              {project.description}
-            </p>
-            <div class="flex flex-wrap gap-2">
-              {project.tags.map((tag) => (
-                <span class="text-xs px-2 py-1 rounded-full bg-[var(--color-border)] text-[var(--color-text-muted)]">
-                  {tag}
-                </span>
-              ))}
-            </div>
-          </a>
-        ))}
+        <ProjectsGrid client:load />
 
         {projects.map((project) => (
           <a
@@ -135,13 +50,7 @@ const builtInProjects = [
         ))}
 
         <!-- Add New Project Card -->
-        <div class="card border-dashed flex flex-col items-center justify-center text-center opacity-60 hover:opacity-100 transition-opacity">
-          <div class="text-4xl mb-4">✨</div>
-          <h3 class="text-lg font-bold mb-2">새 프로젝트</h3>
-          <p class="text-sm text-[var(--color-text-muted)]">
-            Coming Soon...
-          </p>
-        </div>
+        <NewProjectCard client:load />
       </div>
     </div>
   </section>


### PR DESCRIPTION
Apply language settings site-wide (excluding blog posts):
- Header navigation with dynamic translations
- Homepage (hero, recent posts, tools, game center, projects)
- About page with translated content
- Projects page with translated project names/descriptions
- 404 page with translated error messages

New React components for i18n:
- HeaderNav.tsx: Multilingual navigation
- HomeContent.tsx: Homepage sections
- AboutContent.tsx: About page content
- ProjectsContent.tsx: Projects page content
- NotFoundContent.tsx: 404 page content

Extended translations in common.ts for all pages.