### PR TITLE
feat: Add i18n support for LLM cost calculator and other tools

### DIFF
--- a/src/components/tools/AgeCalculator.tsx
+++ b/src/components/tools/AgeCalculator.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from '../../i18n/useTranslation';
 
 interface AgeResult {
   koreanAge: number;
@@ -7,30 +8,33 @@ interface AgeResult {
   days: number;
   totalDays: number;
   nextBirthday: number;
-  zodiac: string;
+  zodiacKey: string;
   zodiacEmoji: string;
-  chineseZodiac: string;
+  chineseZodiacKey: string;
   chineseZodiacEmoji: string;
 }
 
 export default function AgeCalculator() {
+  const { t, translations } = useTranslation();
+  const tc = translations.tools.age;
+
   const [birthDate, setBirthDate] = useState('');
   const [result, setResult] = useState<AgeResult | null>(null);
 
-  const getZodiac = (month: number, day: number): { sign: string; emoji: string } => {
+  const getZodiac = (month: number, day: number): { key: string; emoji: string } => {
     const zodiacSigns = [
-      { sign: '염소자리', emoji: '♑', start: [12, 22], end: [1, 19] },
-      { sign: '물병자리', emoji: '♒', start: [1, 20], end: [2, 18] },
-      { sign: '물고기자리', emoji: '♓', start: [2, 19], end: [3, 20] },
-      { sign: '양자리', emoji: '♈', start: [3, 21], end: [4, 19] },
-      { sign: '황소자리', emoji: '♉', start: [4, 20], end: [5, 20] },
-      { sign: '쌍둥이자리', emoji: '♊', start: [5, 21], end: [6, 21] },
-      { sign: '게자리', emoji: '♋', start: [6, 22], end: [7, 22] },
-      { sign: '사자자리', emoji: '♌', start: [7, 23], end: [8, 22] },
-      { sign: '처녀자리', emoji: '♍', start: [8, 23], end: [9, 22] },
-      { sign: '천칭자리', emoji: '♎', start: [9, 23], end: [10, 22] },
-      { sign: '전갈자리', emoji: '♏', start: [10, 23], end: [11, 21] },
-      { sign: '사수자리', emoji: '♐', start: [11, 22], end: [12, 21] },
+      { key: 'capricorn', emoji: '♑', start: [12, 22], end: [1, 19] },
+      { key: 'aquarius', emoji: '♒', start: [1, 20], end: [2, 18] },
+      { key: 'pisces', emoji: '♓', start: [2, 19], end: [3, 20] },
+      { key: 'aries', emoji: '♈', start: [3, 21], end: [4, 19] },
+      { key: 'taurus', emoji: '♉', start: [4, 20], end: [5, 20] },
+      { key: 'gemini', emoji: '♊', start: [5, 21], end: [6, 21] },
+      { key: 'cancer', emoji: '♋', start: [6, 22], end: [7, 22] },
+      { key: 'leo', emoji: '♌', start: [7, 23], end: [8, 22] },
+      { key: 'virgo', emoji: '♍', start: [8, 23], end: [9, 22] },
+      { key: 'libra', emoji: '♎', start: [9, 23], end: [10, 22] },
+      { key: 'scorpio', emoji: '♏', start: [10, 23], end: [11, 21] },
+      { key: 'sagittarius', emoji: '♐', start: [11, 22], end: [12, 21] },
     ];
 
     for (const z of zodiacSigns) {
@@ -39,31 +43,31 @@ export default function AgeCalculator() {
 
       if (sm > em) {
         if ((month === sm && day >= sd) || (month === em && day <= ed)) {
-          return { sign: z.sign, emoji: z.emoji };
+          return { key: z.key, emoji: z.emoji };
         }
       } else {
         if ((month === sm && day >= sd) || (month === em && day <= ed) || (month > sm && month < em)) {
-          return { sign: z.sign, emoji: z.emoji };
+          return { key: z.key, emoji: z.emoji };
         }
       }
     }
-    return { sign: '염소자리', emoji: '♑' };
+    return { key: 'capricorn', emoji: '♑' };
   };
 
-  const getChineseZodiac = (year: number): { animal: string; emoji: string } => {
+  const getChineseZodiac = (year: number): { key: string; emoji: string } => {
     const animals = [
-      { animal: '원숭이', emoji: '🐵' },
-      { animal: '닭', emoji: '🐔' },
-      { animal: '개', emoji: '🐕' },
-      { animal: '돼지', emoji: '🐷' },
-      { animal: '쥐', emoji: '🐭' },
-      { animal: '소', emoji: '🐮' },
-      { animal: '호랑이', emoji: '🐯' },
-      { animal: '토끼', emoji: '🐰' },
-      { animal: '용', emoji: '🐲' },
-      { animal: '뱀', emoji: '🐍' },
-      { animal: '말', emoji: '🐴' },
-      { animal: '양', emoji: '🐑' },
+      { key: 'monkey', emoji: '🐵' },
+      { key: 'rooster', emoji: '🐔' },
+      { key: 'dog', emoji: '🐕' },
+      { key: 'pig', emoji: '🐷' },
+      { key: 'rat', emoji: '🐭' },
+      { key: 'ox', emoji: '🐮' },
+      { key: 'tiger', emoji: '🐯' },
+      { key: 'rabbit', emoji: '🐰' },
+      { key: 'dragon', emoji: '🐲' },
+      { key: 'snake', emoji: '🐍' },
+      { key: 'horse', emoji: '🐴' },
+      { key: 'sheep', emoji: '🐑' },
     ];
     return animals[year % 12];
   };
@@ -121,19 +125,55 @@ export default function AgeCalculator() {
       days,
       totalDays,
       nextBirthday: daysUntilBirthday,
-      zodiac: zodiac.sign,
+      zodiacKey: zodiac.key,
       zodiacEmoji: zodiac.emoji,
-      chineseZodiac: chineseZodiac.animal,
+      chineseZodiacKey: chineseZodiac.key,
       chineseZodiacEmoji: chineseZodiac.emoji,
     });
   }, [birthDate]);
+
+  const getZodiacName = (key: string) => {
+    const zodiacMap: Record<string, { ko: string; en: string; ja: string }> = {
+      capricorn: tc.capricorn,
+      aquarius: tc.aquarius,
+      pisces: tc.pisces,
+      aries: tc.aries,
+      taurus: tc.taurus,
+      gemini: tc.gemini,
+      cancer: tc.cancer,
+      leo: tc.leo,
+      virgo: tc.virgo,
+      libra: tc.libra,
+      scorpio: tc.scorpio,
+      sagittarius: tc.sagittarius,
+    };
+    return t(zodiacMap[key] || tc.capricorn);
+  };
+
+  const getChineseZodiacName = (key: string) => {
+    const animalMap: Record<string, { ko: string; en: string; ja: string }> = {
+      monkey: tc.monkey,
+      rooster: tc.rooster,
+      dog: tc.dog,
+      pig: tc.pig,
+      rat: tc.rat,
+      ox: tc.ox,
+      tiger: tc.tiger,
+      rabbit: tc.rabbit,
+      dragon: tc.dragon,
+      snake: tc.snake,
+      horse: tc.horse,
+      sheep: tc.sheep,
+    };
+    return t(animalMap[key] || tc.rat);
+  };
 
   return (
     <div className="flex flex-col gap-6">
       {/* Birth Date Input */}
       <div className="space-y-2">
         <label className="block text-sm font-medium text-[var(--color-text)]">
-          생년월일
+          {t(tc.birthDate)}
         </label>
         <input
           type="date"
@@ -152,34 +192,34 @@ export default function AgeCalculator() {
           {/* Main Age Display */}
           <div className="grid grid-cols-2 gap-4">
             <div className="p-4 rounded-lg bg-primary-500/10 border border-primary-500/20 text-center">
-              <p className="text-sm text-[var(--color-text-muted)] mb-1">만 나이</p>
-              <p className="text-4xl font-bold text-primary-500">{result.internationalAge}세</p>
+              <p className="text-sm text-[var(--color-text-muted)] mb-1">{t(tc.internationalAge)}</p>
+              <p className="text-4xl font-bold text-primary-500">{result.internationalAge}{t(tc.years)}</p>
             </div>
             <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)] text-center">
-              <p className="text-sm text-[var(--color-text-muted)] mb-1">세는 나이</p>
-              <p className="text-4xl font-bold text-[var(--color-text)]">{result.koreanAge}세</p>
+              <p className="text-sm text-[var(--color-text-muted)] mb-1">{t(tc.koreanAge)}</p>
+              <p className="text-4xl font-bold text-[var(--color-text)]">{result.koreanAge}{t(tc.years)}</p>
             </div>
           </div>
 
           {/* Detailed Age */}
           <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
             <p className="text-[var(--color-text)]">
-              정확한 나이: <span className="font-bold">{result.internationalAge}년 {result.months}개월 {result.days}일</span>
+              {t(tc.exactAge)}: <span className="font-bold">{result.internationalAge}{t(tc.yearsMonthsDays)} {result.months}{t(tc.monthsUnit)} {result.days}{t(tc.daysUnit)}</span>
             </p>
           </div>
 
           {/* Stats Grid */}
           <div className="grid grid-cols-2 gap-4">
             <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-              <p className="text-sm text-[var(--color-text-muted)] mb-1">살아온 날</p>
+              <p className="text-sm text-[var(--color-text-muted)] mb-1">{t(tc.daysLived)}</p>
               <p className="text-2xl font-bold text-[var(--color-text)]">
-                {result.totalDays.toLocaleString()}일
+                {result.totalDays.toLocaleString()}{t(tc.daysUnit)}
               </p>
             </div>
             <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-              <p className="text-sm text-[var(--color-text-muted)] mb-1">다음 생일까지</p>
+              <p className="text-sm text-[var(--color-text-muted)] mb-1">{t(tc.untilBirthday)}</p>
               <p className="text-2xl font-bold text-[var(--color-text)]">
-                {result.nextBirthday === 0 ? '🎂 오늘!' : `${result.nextBirthday}일`}
+                {result.nextBirthday === 0 ? `🎂 ${t(tc.todayBirthday)}` : `${result.nextBirthday}${t(tc.daysUnit)}`}
               </p>
             </div>
           </div>
@@ -188,24 +228,24 @@ export default function AgeCalculator() {
           <div className="grid grid-cols-2 gap-4">
             <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)] text-center">
               <p className="text-3xl mb-2">{result.zodiacEmoji}</p>
-              <p className="text-sm text-[var(--color-text-muted)]">별자리</p>
-              <p className="font-medium text-[var(--color-text)]">{result.zodiac}</p>
+              <p className="text-sm text-[var(--color-text-muted)]">{t(tc.zodiac)}</p>
+              <p className="font-medium text-[var(--color-text)]">{getZodiacName(result.zodiacKey)}</p>
             </div>
             <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)] text-center">
               <p className="text-3xl mb-2">{result.chineseZodiacEmoji}</p>
-              <p className="text-sm text-[var(--color-text-muted)]">띠</p>
-              <p className="font-medium text-[var(--color-text)]">{result.chineseZodiac}띠</p>
+              <p className="text-sm text-[var(--color-text-muted)]">{t(tc.chineseZodiac)}</p>
+              <p className="font-medium text-[var(--color-text)]">{getChineseZodiacName(result.chineseZodiacKey)}</p>
             </div>
           </div>
 
           {/* Fun Facts */}
           <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-            <h3 className="font-medium text-[var(--color-text)] mb-3">📊 재미있는 통계</h3>
+            <h3 className="font-medium text-[var(--color-text)] mb-3">📊 {t(tc.funStats)}</h3>
             <div className="space-y-2 text-sm text-[var(--color-text-muted)]">
-              <p>• 약 {Math.floor(result.totalDays * 24).toLocaleString()}시간을 살았어요</p>
-              <p>• 약 {Math.floor(result.totalDays * 24 * 60).toLocaleString()}분이 지났어요</p>
-              <p>• 약 {(result.totalDays / 7).toFixed(0)}주를 보냈어요</p>
-              <p>• 심장이 약 {(result.totalDays * 24 * 60 * 72).toLocaleString()}번 뛰었어요</p>
+              <p>• ~{Math.floor(result.totalDays * 24).toLocaleString()} {t(tc.hoursLived)}</p>
+              <p>• ~{Math.floor(result.totalDays * 24 * 60).toLocaleString()} {t(tc.minutesPassed)}</p>
+              <p>• ~{(result.totalDays / 7).toFixed(0)} {t(tc.weeksSpent)}</p>
+              <p>• ~{(result.totalDays * 24 * 60 * 72).toLocaleString()} {t(tc.heartbeats)}</p>
             </div>
           </div>
         </div>

--- a/src/components/tools/BmiCalculator.tsx
+++ b/src/components/tools/BmiCalculator.tsx
@@ -1,15 +1,19 @@
 import { useState } from 'react';
+import { useTranslation } from '../../i18n/useTranslation';
 
 interface BmiResult {
   bmi: number;
-  category: string;
+  categoryKey: string;
   color: string;
-  description: string;
+  descriptionKey: string;
   idealWeightMin: number;
   idealWeightMax: number;
 }
 
 export default function BmiCalculator() {
+  const { t, translations } = useTranslation();
+  const tc = translations.tools.bmi;
+
   const [height, setHeight] = useState('');
   const [weight, setWeight] = useState('');
   const [result, setResult] = useState<BmiResult | null>(null);
@@ -27,53 +31,77 @@ export default function BmiCalculator() {
     const idealWeightMin = 18.5 * h * h;
     const idealWeightMax = 24.9 * h * h;
 
-    let category: string;
+    let categoryKey: string;
     let color: string;
-    let description: string;
+    let descriptionKey: string;
 
     if (bmi < 18.5) {
-      category = '저체중';
+      categoryKey = 'underweight';
       color = 'text-blue-500';
-      description = '체중이 부족합니다. 균형 잡힌 식단으로 건강한 체중을 유지하세요.';
+      descriptionKey = 'underweightDesc';
     } else if (bmi < 23) {
-      category = '정상';
+      categoryKey = 'normal';
       color = 'text-green-500';
-      description = '건강한 체중입니다. 현재 상태를 유지하세요!';
+      descriptionKey = 'normalDesc';
     } else if (bmi < 25) {
-      category = '과체중';
+      categoryKey = 'overweight';
       color = 'text-yellow-500';
-      description = '비만 전 단계입니다. 식이조절과 운동을 권장합니다.';
+      descriptionKey = 'overweightDesc';
     } else if (bmi < 30) {
-      category = '비만 1단계';
+      categoryKey = 'obese1';
       color = 'text-orange-500';
-      description = '건강 관리가 필요합니다. 전문가 상담을 권장합니다.';
+      descriptionKey = 'obese1Desc';
     } else if (bmi < 35) {
-      category = '비만 2단계';
+      categoryKey = 'obese2';
       color = 'text-red-500';
-      description = '건강 위험이 높습니다. 의료 전문가와 상담하세요.';
+      descriptionKey = 'obese2Desc';
     } else {
-      category = '고도비만';
+      categoryKey = 'extremelyObese';
       color = 'text-red-700';
-      description = '심각한 건강 위험이 있습니다. 즉시 의료 상담이 필요합니다.';
+      descriptionKey = 'extremelyObeseDesc';
     }
 
     setResult({
       bmi,
-      category,
+      categoryKey,
       color,
-      description,
+      descriptionKey,
       idealWeightMin,
       idealWeightMax,
     });
   };
 
+  const getCategoryText = (key: string) => {
+    const categoryMap: Record<string, { ko: string; en: string; ja: string }> = {
+      underweight: tc.underweight,
+      normal: tc.normal,
+      overweight: tc.overweight,
+      obese1: tc.obese1,
+      obese2: tc.obese2,
+      extremelyObese: tc.extremelyObese,
+    };
+    return t(categoryMap[key] || tc.normal);
+  };
+
+  const getDescriptionText = (key: string) => {
+    const descMap: Record<string, { ko: string; en: string; ja: string }> = {
+      underweightDesc: tc.underweightDesc,
+      normalDesc: tc.normalDesc,
+      overweightDesc: tc.overweightDesc,
+      obese1Desc: tc.obese1Desc,
+      obese2Desc: tc.obese2Desc,
+      extremelyObeseDesc: tc.extremelyObeseDesc,
+    };
+    return t(descMap[key] || tc.normalDesc);
+  };
+
   const bmiRanges = [
-    { range: '18.5 미만', category: '저체중', color: 'bg-blue-500' },
-    { range: '18.5 - 22.9', category: '정상', color: 'bg-green-500' },
-    { range: '23 - 24.9', category: '과체중', color: 'bg-yellow-500' },
-    { range: '25 - 29.9', category: '비만 1단계', color: 'bg-orange-500' },
-    { range: '30 - 34.9', category: '비만 2단계', color: 'bg-red-500' },
-    { range: '35 이상', category: '고도비만', color: 'bg-red-700' },
+    { range: `18.5 ${t(tc.lessThan)}`, categoryKey: 'underweight', color: 'bg-blue-500' },
+    { range: '18.5 - 22.9', categoryKey: 'normal', color: 'bg-green-500' },
+    { range: '23 - 24.9', categoryKey: 'overweight', color: 'bg-yellow-500' },
+    { range: '25 - 29.9', categoryKey: 'obese1', color: 'bg-orange-500' },
+    { range: '30 - 34.9', categoryKey: 'obese2', color: 'bg-red-500' },
+    { range: `35 ${t(tc.orMore)}`, categoryKey: 'extremelyObese', color: 'bg-red-700' },
   ];
 
   return (
@@ -82,7 +110,7 @@ export default function BmiCalculator() {
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
           <label className="block text-sm font-medium text-[var(--color-text)]">
-            키 (cm)
+            {t(tc.height)}
           </label>
           <input
             type="number"
@@ -96,7 +124,7 @@ export default function BmiCalculator() {
         </div>
         <div className="space-y-2">
           <label className="block text-sm font-medium text-[var(--color-text)]">
-            몸무게 (kg)
+            {t(tc.weight)}
           </label>
           <input
             type="number"
@@ -116,7 +144,7 @@ export default function BmiCalculator() {
         className="w-full py-3 bg-primary-500 hover:bg-primary-600 text-white rounded-lg
           font-medium transition-colors"
       >
-        BMI 계산하기
+        {t(tc.calculate)}
       </button>
 
       {/* Result */}
@@ -124,23 +152,23 @@ export default function BmiCalculator() {
         <div className="space-y-4">
           {/* BMI Value */}
           <div className="text-center p-6 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-            <p className="text-sm text-[var(--color-text-muted)] mb-2">나의 BMI</p>
+            <p className="text-sm text-[var(--color-text-muted)] mb-2">{t(tc.myBmi)}</p>
             <p className={`text-5xl font-bold ${result.color}`}>
               {result.bmi.toFixed(1)}
             </p>
             <p className={`text-xl font-medium mt-2 ${result.color}`}>
-              {result.category}
+              {getCategoryText(result.categoryKey)}
             </p>
           </div>
 
           {/* Description */}
           <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-            <p className="text-[var(--color-text)]">{result.description}</p>
+            <p className="text-[var(--color-text)]">{getDescriptionText(result.descriptionKey)}</p>
           </div>
 
           {/* Ideal Weight */}
           <div className="p-4 rounded-lg bg-green-500/10 border border-green-500/20">
-            <p className="text-sm text-[var(--color-text-muted)] mb-1">적정 체중 범위</p>
+            <p className="text-sm text-[var(--color-text-muted)] mb-1">{t(tc.idealWeight)}</p>
             <p className="text-lg font-medium text-green-500">
               {result.idealWeightMin.toFixed(1)}kg ~ {result.idealWeightMax.toFixed(1)}kg
             </p>
@@ -166,13 +194,13 @@ export default function BmiCalculator() {
 
       {/* BMI Table */}
       <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-        <h3 className="font-medium text-[var(--color-text)] mb-3">📊 BMI 기준표 (아시아-태평양 기준)</h3>
+        <h3 className="font-medium text-[var(--color-text)] mb-3">📊 {t(tc.bmiTable)}</h3>
         <div className="space-y-2">
           {bmiRanges.map((range, i) => (
             <div key={i} className="flex items-center gap-3">
               <div className={`w-4 h-4 rounded ${range.color}`} />
               <span className="text-sm text-[var(--color-text-muted)] w-24">{range.range}</span>
-              <span className="text-sm text-[var(--color-text)]">{range.category}</span>
+              <span className="text-sm text-[var(--color-text)]">{getCategoryText(range.categoryKey)}</span>
             </div>
           ))}
         </div>
@@ -180,7 +208,7 @@ export default function BmiCalculator() {
 
       {/* Disclaimer */}
       <p className="text-xs text-[var(--color-text-muted)] text-center">
-        * BMI는 참고용 지표입니다. 정확한 건강 상태는 전문가와 상담하세요.
+        * {t(tc.disclaimer)}
       </p>
     </div>
   );

--- a/src/components/tools/TimestampConverter.tsx
+++ b/src/components/tools/TimestampConverter.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from '../../i18n/useTranslation';
 
 export default function TimestampConverter() {
+  const { t, lang, translations } = useTranslation();
+  const tc = translations.tools.timestamp;
+  const tcc = translations.tools.common;
+
   const [timestamp, setTimestamp] = useState('');
   const [dateString, setDateString] = useState('');
   const [currentTime, setCurrentTime] = useState(Date.now());
@@ -34,7 +39,8 @@ export default function TimestampConverter() {
   const dateTimestamp = parseDateString(dateString);
 
   const formatDate = (date: Date): string => {
-    return date.toLocaleString('ko-KR', {
+    const locale = lang === 'ko' ? 'ko-KR' : lang === 'ja' ? 'ja-JP' : 'en-US';
+    return date.toLocaleString(locale, {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -63,14 +69,14 @@ export default function TimestampConverter() {
     const years = Math.floor(days / 365);
 
     let result = '';
-    if (years > 0) result = `${years}년`;
-    else if (months > 0) result = `${months}개월`;
-    else if (days > 0) result = `${days}일`;
-    else if (hours > 0) result = `${hours}시간`;
-    else if (minutes > 0) result = `${minutes}분`;
-    else result = `${seconds}초`;
+    if (years > 0) result = `${years}${t(tc.yearsAgo)}`;
+    else if (months > 0) result = `${months}${t(tc.monthsAgo)}`;
+    else if (days > 0) result = `${days}${t(tc.daysAgo)}`;
+    else if (hours > 0) result = `${hours}${t(tc.hoursAgo)}`;
+    else if (minutes > 0) result = `${minutes}${t(tc.minutesAgo)}`;
+    else result = `${seconds}${t(tc.secondsAgo)}`;
 
-    return diff > 0 ? `${result} 전` : `${result} 후`;
+    return diff > 0 ? `${result} ${t(tc.ago)}` : `${result} ${t(tc.later)}`;
   };
 
   const copyText = async (text: string) => {
@@ -83,13 +89,23 @@ export default function TimestampConverter() {
 
   const currentTimestamp = unit === 'milliseconds' ? currentTime : Math.floor(currentTime / 1000);
 
+  const commonTimes = [
+    { labelKey: 'inOneHour' as const, getTs: () => Math.floor(Date.now() / 1000) + 3600 },
+    { labelKey: 'tomorrow' as const, getTs: () => Math.floor(Date.now() / 1000) + 86400 },
+    { labelKey: 'inOneWeek' as const, getTs: () => Math.floor(Date.now() / 1000) + 604800 },
+    { labelKey: 'inOneMonth' as const, getTs: () => Math.floor(Date.now() / 1000) + 2592000 },
+    { label: '2000/1/1', getTs: () => 946684800 },
+    { label: '2024/1/1', getTs: () => 1704067200 },
+    { label: '2025/1/1', getTs: () => 1735689600 },
+  ];
+
   return (
     <div className="flex flex-col gap-6">
       {/* Current Time */}
       <div className="p-4 rounded-xl bg-gradient-to-r from-primary-500/10 to-primary-500/5 border border-primary-500/20">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm text-[var(--color-text-muted)]">현재 Unix Timestamp</p>
+            <p className="text-sm text-[var(--color-text-muted)]">{t(tc.currentTimestamp)}</p>
             <p className="text-2xl font-mono font-bold text-primary-500">
               {currentTimestamp}
             </p>
@@ -101,7 +117,7 @@ export default function TimestampConverter() {
             }}
             className="px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg text-sm font-medium transition-colors"
           >
-            복사 & 사용
+            {t(tc.copyAndUse)}
           </button>
         </div>
         <p className="text-sm text-[var(--color-text-muted)] mt-2">
@@ -119,7 +135,7 @@ export default function TimestampConverter() {
               : 'bg-[var(--color-card)] hover:bg-[var(--color-card-hover)] text-[var(--color-text)] border border-[var(--color-border)]'
             }`}
         >
-          초 (Seconds)
+          {t(tc.seconds)}
         </button>
         <button
           onClick={() => setUnit('milliseconds')}
@@ -129,13 +145,13 @@ export default function TimestampConverter() {
               : 'bg-[var(--color-card)] hover:bg-[var(--color-card-hover)] text-[var(--color-text)] border border-[var(--color-border)]'
             }`}
         >
-          밀리초 (Milliseconds)
+          {t(tc.milliseconds)}
         </button>
       </div>
 
       {/* Timestamp to Date */}
       <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-        <h3 className="font-medium text-[var(--color-text)] mb-4">⏱️ Timestamp → 날짜</h3>
+        <h3 className="font-medium text-[var(--color-text)] mb-4">⏱️ {t(tc.timestampToDate)}</h3>
         <div className="space-y-4">
           <input
             type="text"
@@ -150,7 +166,7 @@ export default function TimestampConverter() {
           {timestampDate && (
             <div className="space-y-2">
               <div className="p-3 rounded-lg bg-[var(--color-bg)]">
-                <p className="text-sm text-[var(--color-text-muted)]">로컬 시간</p>
+                <p className="text-sm text-[var(--color-text-muted)]">{t(tc.localTime)}</p>
                 <p className="font-medium text-[var(--color-text)]">{formatDate(timestampDate)}</p>
               </div>
               <div className="p-3 rounded-lg bg-[var(--color-bg)]">
@@ -158,7 +174,7 @@ export default function TimestampConverter() {
                 <p className="font-mono text-[var(--color-text)]">{formatISO(timestampDate)}</p>
               </div>
               <div className="p-3 rounded-lg bg-[var(--color-bg)]">
-                <p className="text-sm text-[var(--color-text-muted)]">상대 시간</p>
+                <p className="text-sm text-[var(--color-text-muted)]">{t(tc.relativeTime)}</p>
                 <p className="font-medium text-primary-500">{formatRelative(timestampDate)}</p>
               </div>
             </div>
@@ -168,7 +184,7 @@ export default function TimestampConverter() {
 
       {/* Date to Timestamp */}
       <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-        <h3 className="font-medium text-[var(--color-text)] mb-4">📅 날짜 → Timestamp</h3>
+        <h3 className="font-medium text-[var(--color-text)] mb-4">📅 {t(tc.dateToTimestamp)}</h3>
         <div className="space-y-4">
           <input
             type="datetime-local"
@@ -189,7 +205,7 @@ export default function TimestampConverter() {
                 onClick={() => copyText(String(dateTimestamp))}
                 className="px-3 py-1 bg-primary-500 hover:bg-primary-600 text-white rounded-lg text-sm transition-colors"
               >
-                복사
+                {t(tcc.copy)}
               </button>
             </div>
           )}
@@ -198,24 +214,16 @@ export default function TimestampConverter() {
 
       {/* Common Timestamps */}
       <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-        <h3 className="font-medium text-[var(--color-text)] mb-3">📌 자주 사용하는 시간</h3>
+        <h3 className="font-medium text-[var(--color-text)] mb-3">📌 {t(tc.commonTimestamps)}</h3>
         <div className="space-y-2">
-          {[
-            { label: '1시간 후', getTs: () => Math.floor(Date.now() / 1000) + 3600 },
-            { label: '내일', getTs: () => Math.floor(Date.now() / 1000) + 86400 },
-            { label: '1주일 후', getTs: () => Math.floor(Date.now() / 1000) + 604800 },
-            { label: '1개월 후', getTs: () => Math.floor(Date.now() / 1000) + 2592000 },
-            { label: '2000년 1월 1일', getTs: () => 946684800 },
-            { label: '2024년 1월 1일', getTs: () => 1704067200 },
-            { label: '2025년 1월 1일', getTs: () => 1735689600 },
-          ].map((item) => (
+          {commonTimes.map((item, idx) => (
             <button
-              key={item.label}
+              key={idx}
               onClick={() => setTimestamp(String(unit === 'milliseconds' ? item.getTs() * 1000 : item.getTs()))}
               className="w-full p-2 rounded-lg text-left hover:bg-[var(--color-bg)]
                 text-[var(--color-text-muted)] transition-colors flex justify-between"
             >
-              <span>{item.label}</span>
+              <span>{'labelKey' in item ? t(tc[item.labelKey]) : item.label}</span>
               <span className="font-mono text-sm">{item.getTs()}</span>
             </button>
           ))}
@@ -224,10 +232,9 @@ export default function TimestampConverter() {
 
       {/* Info */}
       <div className="p-4 rounded-lg bg-[var(--color-card)] border border-[var(--color-border)]">
-        <h3 className="font-medium text-[var(--color-text)] mb-2">💡 Unix Timestamp란?</h3>
+        <h3 className="font-medium text-[var(--color-text)] mb-2">💡 {t(tc.whatIsTimestamp)}</h3>
         <p className="text-sm text-[var(--color-text-muted)]">
-          1970년 1월 1일 00:00:00 UTC부터 경과한 시간을 초(또는 밀리초)로 표현한 값입니다.
-          프로그래밍에서 시간을 다룰 때 널리 사용됩니다.
+          {t(tc.timestampExplanation)}
         </p>
       </div>
     </div>

--- a/src/i18n/translations/tools.ts
+++ b/src/i18n/translations/tools.ts
@@ -213,6 +213,249 @@ export const toolTranslations = {
     infoNote: { ko: '모든 이미지 처리는 브라우저에서 로컬로 수행됩니다. 이미지는 서버로 전송되지 않습니다.', en: 'All image processing is done locally in your browser. Images are not sent to any server.', ja: 'すべての画像処理はブラウザでローカルに行われます。画像はサーバーに送信されません。' },
   },
 
+  // LLM Cost Calculator
+  llmCost: {
+    title: { ko: 'LLM 비용 계산기', en: 'LLM Cost Calculator', ja: 'LLMコスト計算機' },
+    description: { ko: 'AI 모델별 API 사용 비용 비교', en: 'Compare API costs across AI models', ja: 'AIモデル別APIコストを比較' },
+
+    // Input modes
+    textMode: { ko: '텍스트로 토큰 계산', en: 'Calculate tokens from text', ja: 'テキストからトークン計算' },
+    manualMode: { ko: '토큰 수 직접 입력', en: 'Enter token count manually', ja: 'トークン数を直接入力' },
+
+    // Labels
+    inputText: { ko: '입력 텍스트 (Input)', en: 'Input Text', ja: '入力テキスト' },
+    outputText: { ko: '출력 텍스트 (Output) - 예상 응답', en: 'Output Text - Expected Response', ja: '出力テキスト - 予想応答' },
+    inputTokens: { ko: '입력 토큰 수', en: 'Input Tokens', ja: '入力トークン数' },
+    outputTokens: { ko: '출력 토큰 수', en: 'Output Tokens', ja: '出力トークン数' },
+    outputTokensAlt: { ko: '또는 출력 토큰 수 직접 입력', en: 'Or enter output tokens manually', ja: 'または出力トークン数を直接入力' },
+    requestCount: { ko: '요청 횟수', en: 'Request Count', ja: 'リクエスト回数' },
+
+    // Placeholders
+    inputPlaceholder: { ko: '프롬프트를 입력하세요...', en: 'Enter your prompt...', ja: 'プロンプトを入力...' },
+    outputPlaceholder: { ko: '예상되는 출력 텍스트를 입력하거나, 아래에서 출력 토큰 수를 직접 입력하세요...', en: 'Enter expected output text, or manually enter output token count below...', ja: '予想される出力テキストを入力するか、下で出力トークン数を直接入力...' },
+
+    // Presets
+    presetShort: { ko: '짧은 답변', en: 'Short Answer', ja: '短い回答' },
+    presetNormal: { ko: '일반 대화', en: 'Normal Chat', ja: '通常の会話' },
+    presetLong: { ko: '긴 글 작성', en: 'Long Writing', ja: '長文作成' },
+    presetCode: { ko: '코드 생성', en: 'Code Generation', ja: 'コード生成' },
+    presetDoc: { ko: '문서 분석', en: 'Document Analysis', ja: 'ドキュメント分析' },
+    presetBulk: { ko: '대량 처리 (1000건)', en: 'Bulk Processing (1000)', ja: '大量処理 (1000件)' },
+
+    // Token summary
+    inputTokensSummary: { ko: '입력 토큰', en: 'Input Tokens', ja: '入力トークン' },
+    outputTokensSummary: { ko: '출력 토큰', en: 'Output Tokens', ja: '出力トークン' },
+    requestsSummary: { ko: '요청 횟수', en: 'Requests', ja: 'リクエスト数' },
+
+    // Currency
+    currencySelect: { ko: '통화 선택', en: 'Select Currency', ja: '通貨を選択' },
+    exchangeSettings: { ko: '환율 설정', en: 'Exchange Rate Settings', ja: '為替レート設定' },
+    exchangeClose: { ko: '환율 설정 닫기', en: 'Close Exchange Settings', ja: '為替レート設定を閉じる' },
+    exchangeRate: { ko: '$1 USD 기준 환율', en: 'Exchange rate per $1 USD', ja: '$1 USDあたりの為替レート' },
+    fetchRates: { ko: '실시간 환율 가져오기', en: 'Fetch Live Rates', ja: 'リアルタイムレートを取得' },
+    fetchingRates: { ko: '가져오는 중...', en: 'Fetching...', ja: '取得中...' },
+    ratesError: { ko: '환율 데이터를 가져올 수 없습니다.', en: 'Could not fetch exchange rates.', ja: '為替レートを取得できませんでした。' },
+    networkError: { ko: '네트워크 오류가 발생했습니다.', en: 'Network error occurred.', ja: 'ネットワークエラーが発生しました。' },
+    lastUpdated: { ko: '마지막 업데이트', en: 'Last updated', ja: '最終更新' },
+    defaultRates: { ko: '기본 환율 사용 중', en: 'Using default rates', ja: 'デフォルトレートを使用中' },
+    exchangeSource: { ko: '출처', en: 'Source', ja: '出典' },
+
+    // Currency names
+    currencyUsd: { ko: '달러', en: 'USD', ja: 'ドル' },
+    currencyKrw: { ko: '원화', en: 'KRW', ja: 'ウォン' },
+    currencyJpy: { ko: '엔화', en: 'JPY', ja: '円' },
+    currencyEur: { ko: '유로', en: 'EUR', ja: 'ユーロ' },
+
+    // Provider filter
+    providerFilter: { ko: '제공업체 필터 (복수 선택)', en: 'Provider Filter (Multi-select)', ja: 'プロバイダーフィルター (複数選択)' },
+    selectAll: { ko: '전체 선택', en: 'Select All', ja: 'すべて選択' },
+    deselectAll: { ko: '전체 해제', en: 'Deselect All', ja: 'すべて解除' },
+    modelSelect: { ko: '모델 개별 선택', en: 'Select Models', ja: 'モデルを個別選択' },
+    modelSelectClose: { ko: '모델 선택 닫기', en: 'Close Model Selection', ja: 'モデル選択を閉じる' },
+    select: { ko: '선택', en: 'Select', ja: '選択' },
+    deselect: { ko: '해제', en: 'Deselect', ja: '解除' },
+
+    // Table headers
+    model: { ko: '모델', en: 'Model', ja: 'モデル' },
+    inputCost: { ko: '입력 비용', en: 'Input Cost', ja: '入力コスト' },
+    outputCost: { ko: '출력 비용', en: 'Output Cost', ja: '出力コスト' },
+    totalCost: { ko: '총 비용', en: 'Total Cost', ja: '合計コスト' },
+    comparison: { ko: '비교', en: 'Comparison', ja: '比較' },
+    lowest: { ko: '최저가', en: 'Lowest', ja: '最安' },
+    selectModels: { ko: '비교할 모델을 선택하세요.', en: 'Select models to compare.', ja: '比較するモデルを選択してください。' },
+
+    // Pricing table
+    pricingTable: { ko: '모델별 토큰당 가격', en: 'Price per Token by Model', ja: 'モデル別トークン単価' },
+    pricePer1kInput: { ko: '입력 1K당', en: 'Per 1K Input', ja: '入力1Kあたり' },
+    pricePer1kOutput: { ko: '출력 1K당', en: 'Per 1K Output', ja: '出力1Kあたり' },
+    maxInput: { ko: '최대 입력', en: 'Max Input', ja: '最大入力' },
+    maxOutput: { ko: '최대 출력', en: 'Max Output', ja: '最大出力' },
+
+    // Notes section
+    notes: { ko: '참고 사항', en: 'Notes', ja: '注意事項' },
+    priceDate: { ko: '가격은 2025년 1월 기준이며 실제 가격은 공식 사이트에서 확인하세요.', en: 'Prices as of January 2025. Check official sites for current pricing.', ja: '価格は2025年1月時点のものです。最新価格は公式サイトでご確認ください。' },
+    tokenEstimation: { ko: '토큰 수 추정: 영어 약 4자당 1토큰, 한국어 약 2자당 1토큰', en: 'Token estimation: ~4 English chars per token, ~2 Korean chars per token', ja: 'トークン推定: 英語約4文字で1トークン、韓国語約2文字で1トークン' },
+    koreanTokenNote: { ko: '한국어는 영어보다 토큰을 더 많이 사용합니다 (~1.5-2배).', en: 'Korean uses more tokens than English (~1.5-2x).', ja: '韓国語は英語より多くのトークンを使用します（約1.5-2倍）。' },
+    exchangeNote: { ko: '환율은 페이지 로드 시 자동으로', en: 'Exchange rates are auto-fetched from', ja: '為替レートはページ読み込み時に' },
+    exchangeNoteSuffix: { ko: '에서 가져옵니다.', en: 'on page load.', ja: 'から自動取得されます。' },
+
+    // Token references
+    tokenReference: { ko: '토큰 계산 레퍼런스', en: 'Token Calculation Reference', ja: 'トークン計算リファレンス' },
+    openaiTokenizer: { ko: 'GPT 모델용 토큰 계산기', en: 'Tokenizer for GPT models', ja: 'GPTモデル用トークナイザー' },
+    anthropicTokens: { ko: 'Claude 모델 토큰 계산 API', en: 'Token counting API for Claude models', ja: 'ClaudeモデルのトークンカウントAPI' },
+    geminiTokens: { ko: 'Gemini 모델 토큰 가이드', en: 'Token guide for Gemini models', ja: 'Geminiモデルのトークンガイド' },
+
+    // Price sources
+    priceSources: { ko: '가격 정보 출처', en: 'Pricing Sources', ja: '価格情報ソース' },
+    priceSourceNote: { ko: '아래 공식 가격 페이지에서 최신 정보를 확인하세요:', en: 'Check the official pricing pages below for latest information:', ja: '以下の公式価格ページで最新情報をご確認ください:' },
+
+    // Character count
+    characters: { ko: '자', en: 'chars', ja: '文字' },
+    tokensEstimated: { ko: '토큰 (추정)', en: 'tokens (est.)', ja: 'トークン（推定）' },
+  },
+
+  // Age Calculator
+  age: {
+    title: { ko: '나이 계산기', en: 'Age Calculator', ja: '年齢計算機' },
+    description: { ko: '생년월일로 나이 계산', en: 'Calculate age from birthdate', ja: '生年月日から年齢を計算' },
+    birthDate: { ko: '생년월일', en: 'Birth Date', ja: '生年月日' },
+    internationalAge: { ko: '만 나이', en: 'International Age', ja: '満年齢' },
+    koreanAge: { ko: '세는 나이', en: 'Korean Age', ja: '数え年' },
+    years: { ko: '세', en: ' years old', ja: '歳' },
+    exactAge: { ko: '정확한 나이', en: 'Exact Age', ja: '正確な年齢' },
+    yearsMonthsDays: { ko: '년', en: ' years ', ja: '年' },
+    monthsUnit: { ko: '개월', en: ' months ', ja: 'ヶ月' },
+    daysUnit: { ko: '일', en: ' days', ja: '日' },
+    daysLived: { ko: '살아온 날', en: 'Days Lived', ja: '生きた日数' },
+    untilBirthday: { ko: '다음 생일까지', en: 'Until Birthday', ja: '次の誕生日まで' },
+    todayBirthday: { ko: '오늘!', en: 'Today!', ja: '今日!' },
+    zodiac: { ko: '별자리', en: 'Zodiac', ja: '星座' },
+    chineseZodiac: { ko: '띠', en: 'Chinese Zodiac', ja: '干支' },
+    funStats: { ko: '재미있는 통계', en: 'Fun Statistics', ja: '楽しい統計' },
+    hoursLived: { ko: '시간을 살았어요', en: 'hours lived', ja: '時間を生きました' },
+    minutesPassed: { ko: '분이 지났어요', en: 'minutes passed', ja: '分が経ちました' },
+    weeksSpent: { ko: '주를 보냈어요', en: 'weeks spent', ja: '週を過ごしました' },
+    heartbeats: { ko: '번 뛰었어요', en: 'heartbeats', ja: '回鼓動しました' },
+    // Zodiac signs
+    capricorn: { ko: '염소자리', en: 'Capricorn', ja: '山羊座' },
+    aquarius: { ko: '물병자리', en: 'Aquarius', ja: '水瓶座' },
+    pisces: { ko: '물고기자리', en: 'Pisces', ja: '魚座' },
+    aries: { ko: '양자리', en: 'Aries', ja: '牡羊座' },
+    taurus: { ko: '황소자리', en: 'Taurus', ja: '牡牛座' },
+    gemini: { ko: '쌍둥이자리', en: 'Gemini', ja: '双子座' },
+    cancer: { ko: '게자리', en: 'Cancer', ja: '蟹座' },
+    leo: { ko: '사자자리', en: 'Leo', ja: '獅子座' },
+    virgo: { ko: '처녀자리', en: 'Virgo', ja: '乙女座' },
+    libra: { ko: '천칭자리', en: 'Libra', ja: '天秤座' },
+    scorpio: { ko: '전갈자리', en: 'Scorpio', ja: '蠍座' },
+    sagittarius: { ko: '사수자리', en: 'Sagittarius', ja: '射手座' },
+    // Chinese zodiac
+    monkey: { ko: '원숭이', en: 'Monkey', ja: '申' },
+    rooster: { ko: '닭', en: 'Rooster', ja: '酉' },
+    dog: { ko: '개', en: 'Dog', ja: '戌' },
+    pig: { ko: '돼지', en: 'Pig', ja: '亥' },
+    rat: { ko: '쥐', en: 'Rat', ja: '子' },
+    ox: { ko: '소', en: 'Ox', ja: '丑' },
+    tiger: { ko: '호랑이', en: 'Tiger', ja: '寅' },
+    rabbit: { ko: '토끼', en: 'Rabbit', ja: '卯' },
+    dragon: { ko: '용', en: 'Dragon', ja: '辰' },
+    snake: { ko: '뱀', en: 'Snake', ja: '巳' },
+    horse: { ko: '말', en: 'Horse', ja: '午' },
+    sheep: { ko: '양', en: 'Sheep', ja: '未' },
+  },
+
+  // BMI Calculator
+  bmi: {
+    title: { ko: 'BMI 계산기', en: 'BMI Calculator', ja: 'BMI計算機' },
+    description: { ko: '체질량지수 계산', en: 'Calculate Body Mass Index', ja: '体格指数を計算' },
+    height: { ko: '키 (cm)', en: 'Height (cm)', ja: '身長 (cm)' },
+    weight: { ko: '몸무게 (kg)', en: 'Weight (kg)', ja: '体重 (kg)' },
+    calculate: { ko: 'BMI 계산하기', en: 'Calculate BMI', ja: 'BMIを計算' },
+    myBmi: { ko: '나의 BMI', en: 'My BMI', ja: '私のBMI' },
+    idealWeight: { ko: '적정 체중 범위', en: 'Ideal Weight Range', ja: '理想体重範囲' },
+    underweight: { ko: '저체중', en: 'Underweight', ja: '低体重' },
+    normal: { ko: '정상', en: 'Normal', ja: '普通' },
+    overweight: { ko: '과체중', en: 'Overweight', ja: '過体重' },
+    obese1: { ko: '비만 1단계', en: 'Obese Class I', ja: '肥満1度' },
+    obese2: { ko: '비만 2단계', en: 'Obese Class II', ja: '肥満2度' },
+    extremelyObese: { ko: '고도비만', en: 'Extremely Obese', ja: '高度肥満' },
+    underweightDesc: { ko: '체중이 부족합니다. 균형 잡힌 식단으로 건강한 체중을 유지하세요.', en: 'You are underweight. Maintain a healthy weight with a balanced diet.', ja: '体重が不足しています。バランスの取れた食事で健康的な体重を維持してください。' },
+    normalDesc: { ko: '건강한 체중입니다. 현재 상태를 유지하세요!', en: 'You have a healthy weight. Keep it up!', ja: '健康的な体重です。この状態を維持しましょう！' },
+    overweightDesc: { ko: '비만 전 단계입니다. 식이조절과 운동을 권장합니다.', en: 'Pre-obesity stage. Diet and exercise recommended.', ja: '肥満予備軍です。食事制限と運動をお勧めします。' },
+    obese1Desc: { ko: '건강 관리가 필요합니다. 전문가 상담을 권장합니다.', en: 'Health management needed. Professional consultation recommended.', ja: '健康管理が必要です。専門家への相談をお勧めします。' },
+    obese2Desc: { ko: '건강 위험이 높습니다. 의료 전문가와 상담하세요.', en: 'High health risk. Consult a medical professional.', ja: '健康リスクが高いです。医療専門家にご相談ください。' },
+    extremelyObeseDesc: { ko: '심각한 건강 위험이 있습니다. 즉시 의료 상담이 필요합니다.', en: 'Serious health risk. Immediate medical consultation needed.', ja: '深刻な健康リスクがあります。直ちに医療相談が必要です。' },
+    bmiTable: { ko: 'BMI 기준표 (아시아-태평양 기준)', en: 'BMI Reference (Asia-Pacific)', ja: 'BMI基準表（アジア太平洋基準）' },
+    disclaimer: { ko: 'BMI는 참고용 지표입니다. 정확한 건강 상태는 전문가와 상담하세요.', en: 'BMI is for reference only. Consult a professional for accurate health status.', ja: 'BMIは参考指標です。正確な健康状態は専門家にご相談ください。' },
+    lessThan: { ko: '미만', en: 'under', ja: '未満' },
+    orMore: { ko: '이상', en: 'or more', ja: '以上' },
+  },
+
+  // Timestamp Converter
+  timestamp: {
+    title: { ko: '타임스탬프 변환기', en: 'Timestamp Converter', ja: 'タイムスタンプ変換器' },
+    description: { ko: 'Unix 타임스탬프 변환', en: 'Convert Unix timestamps', ja: 'Unixタイムスタンプを変換' },
+    currentTimestamp: { ko: '현재 Unix Timestamp', en: 'Current Unix Timestamp', ja: '現在のUnixタイムスタンプ' },
+    copyAndUse: { ko: '복사 & 사용', en: 'Copy & Use', ja: 'コピー＆使用' },
+    seconds: { ko: '초 (Seconds)', en: 'Seconds', ja: '秒 (Seconds)' },
+    milliseconds: { ko: '밀리초 (Milliseconds)', en: 'Milliseconds', ja: 'ミリ秒 (Milliseconds)' },
+    timestampToDate: { ko: 'Timestamp → 날짜', en: 'Timestamp → Date', ja: 'タイムスタンプ → 日付' },
+    dateToTimestamp: { ko: '날짜 → Timestamp', en: 'Date → Timestamp', ja: '日付 → タイムスタンプ' },
+    localTime: { ko: '로컬 시간', en: 'Local Time', ja: 'ローカル時間' },
+    relativeTime: { ko: '상대 시간', en: 'Relative Time', ja: '相対時間' },
+    commonTimestamps: { ko: '자주 사용하는 시간', en: 'Common Timestamps', ja: 'よく使う時間' },
+    inOneHour: { ko: '1시간 후', en: 'In 1 hour', ja: '1時間後' },
+    tomorrow: { ko: '내일', en: 'Tomorrow', ja: '明日' },
+    inOneWeek: { ko: '1주일 후', en: 'In 1 week', ja: '1週間後' },
+    inOneMonth: { ko: '1개월 후', en: 'In 1 month', ja: '1ヶ月後' },
+    whatIsTimestamp: { ko: 'Unix Timestamp란?', en: 'What is Unix Timestamp?', ja: 'Unixタイムスタンプとは？' },
+    timestampExplanation: { ko: '1970년 1월 1일 00:00:00 UTC부터 경과한 시간을 초(또는 밀리초)로 표현한 값입니다. 프로그래밍에서 시간을 다룰 때 널리 사용됩니다.', en: 'A value representing the time elapsed since January 1, 1970 00:00:00 UTC in seconds (or milliseconds). Widely used in programming for handling time.', ja: '1970年1月1日 00:00:00 UTCからの経過時間を秒（またはミリ秒）で表した値です。プログラミングで時間を扱う際に広く使用されています。' },
+    ago: { ko: '전', en: 'ago', ja: '前' },
+    later: { ko: '후', en: 'later', ja: '後' },
+    yearsAgo: { ko: '년', en: ' year(s)', ja: '年' },
+    monthsAgo: { ko: '개월', en: ' month(s)', ja: 'ヶ月' },
+    daysAgo: { ko: '일', en: ' day(s)', ja: '日' },
+    hoursAgo: { ko: '시간', en: ' hour(s)', ja: '時間' },
+    minutesAgo: { ko: '분', en: ' minute(s)', ja: '分' },
+    secondsAgo: { ko: '초', en: ' second(s)', ja: '秒' },
+  },
+
+  // D-Day Calculator
+  dday: {
+    title: { ko: 'D-Day 계산기', en: 'D-Day Calculator', ja: 'D-Day計算機' },
+    description: { ko: '특정 날짜까지 남은 일수 계산', en: 'Calculate days until a specific date', ja: '特定の日付までの日数を計算' },
+    targetDate: { ko: '목표 날짜', en: 'Target Date', ja: '目標日' },
+    eventName: { ko: '이벤트 이름 (선택)', en: 'Event Name (Optional)', ja: 'イベント名（任意）' },
+    daysRemaining: { ko: '남은 일수', en: 'Days Remaining', ja: '残り日数' },
+    daysPassed: { ko: '지난 일수', en: 'Days Passed', ja: '経過日数' },
+    today: { ko: '오늘', en: 'Today', ja: '今日' },
+    addEvent: { ko: '이벤트 추가', en: 'Add Event', ja: 'イベント追加' },
+    savedEvents: { ko: '저장된 이벤트', en: 'Saved Events', ja: '保存されたイベント' },
+    noEvents: { ko: '저장된 이벤트가 없습니다', en: 'No saved events', ja: '保存されたイベントがありません' },
+  },
+
+  // Discount Calculator
+  discount: {
+    title: { ko: '할인 계산기', en: 'Discount Calculator', ja: '割引計算機' },
+    description: { ko: '할인 금액 및 최종 가격 계산', en: 'Calculate discount amount and final price', ja: '割引額と最終価格を計算' },
+    originalPrice: { ko: '원래 가격', en: 'Original Price', ja: '元の価格' },
+    discountRate: { ko: '할인율 (%)', en: 'Discount Rate (%)', ja: '割引率 (%)' },
+    discountAmount: { ko: '할인 금액', en: 'Discount Amount', ja: '割引額' },
+    finalPrice: { ko: '최종 가격', en: 'Final Price', ja: '最終価格' },
+    youSave: { ko: '절약 금액', en: 'You Save', ja: '節約額' },
+  },
+
+  // Dutch Pay Calculator
+  dutchPay: {
+    title: { ko: '더치페이 계산기', en: 'Split Bill Calculator', ja: '割り勘計算機' },
+    description: { ko: '총 금액을 인원수로 나누기', en: 'Split total amount by number of people', ja: '合計金額を人数で分割' },
+    totalAmount: { ko: '총 금액', en: 'Total Amount', ja: '合計金額' },
+    numberOfPeople: { ko: '인원 수', en: 'Number of People', ja: '人数' },
+    perPerson: { ko: '1인당 금액', en: 'Per Person', ja: '一人当たり' },
+    remainder: { ko: '나머지', en: 'Remainder', ja: '余り' },
+    addExtra: { ko: '추가 금액', en: 'Additional Amount', ja: '追加金額' },
+  },
+
   // Tools page
   toolsPage: {
     title: { ko: '온라인 도구', en: 'Online Tools', ja: 'オンラインツール' },


### PR DESCRIPTION
- Add useTranslation hook to LlmCostCalculator with full i18n support
- Add pricing sources section with links to official pricing pages
- Add collapsible pricing table showing per-token costs for all models
- Add i18n support to AgeCalculator, BmiCalculator, TimestampConverter
- Add translations for all new components in tools.ts