### PR TITLE
fix: Improve chat scroll behavior

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -133,7 +133,7 @@ export default function Chat() {
   }, [status]);
 
   return (
-    <div className="flex flex-col h-[calc(100vh-120px)] max-w-3xl mx-auto border border-[var(--color-border)] rounded-lg overflow-hidden bg-[var(--color-card)]">
+    <div className="flex flex-col h-full max-w-3xl mx-auto border border-[var(--color-border)] rounded-lg overflow-hidden bg-[var(--color-card)]">
       {/* 헤더 */}
       <div
         className="flex items-center justify-between px-4 py-2 border-b border-[var(--color-border)] bg-[var(--color-bg)]"
@@ -203,6 +203,7 @@ export default function Chat() {
 
       {/* 메시지 영역 */}
       <div
+        ref={messagesEndRef}
         className="flex-1 overflow-y-auto p-4 space-y-3"
         role="log"
         aria-label={t(tt.messages.emptyChat)}
@@ -247,7 +248,6 @@ export default function Chat() {
             </div>
           );
         })}
-        <div ref={messagesEndRef} aria-hidden="true" />
       </div>
 
       {/* 만료/에러 상태 */}

--- a/src/hooks/useScrollToBottom.ts
+++ b/src/hooks/useScrollToBottom.ts
@@ -1,11 +1,19 @@
 import { useEffect, useRef } from 'react';
 
-export function useScrollToBottom<T>(dependency: T) {
-  const elementRef = useRef<HTMLDivElement>(null);
+export function useScrollToBottom<T extends unknown[]>(dependency: T) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const prevLengthRef = useRef(0);
 
   useEffect(() => {
-    elementRef.current?.scrollIntoView({ behavior: 'smooth' });
+    // 메시지가 추가됐을 때만 스크롤 (초기 로드 시 스크롤 방지)
+    if (dependency.length > prevLengthRef.current && dependency.length > 0) {
+      const container = containerRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+    }
+    prevLengthRef.current = dependency.length;
   }, [dependency]);
 
-  return elementRef;
+  return containerRef;
 }

--- a/src/pages/anonymous-chat.astro
+++ b/src/pages/anonymous-chat.astro
@@ -12,7 +12,19 @@ const tt = chatTranslations;
   title={`${tt.pageTitle[lang]} | Restato`}
   description={tt.pageDescription[lang]}
 >
-  <div class="container mx-auto px-4 py-4">
+  <div class="chat-container px-4 py-2">
     <Chat client:load />
   </div>
 </MainLayout>
+
+<style>
+  .chat-container {
+    height: calc(100vh - 140px);
+  }
+
+  @media (max-width: 768px) {
+    .chat-container {
+      height: calc(100vh - 120px);
+    }
+  }
+</style>


### PR DESCRIPTION
- Only scroll message container, not entire page
- Prevent automatic scroll on page refresh
- Track previous message count to scroll only when new messages added
- Use scrollTop instead of scrollIntoView for container-only scrolling
- Optimize chat container height with calc(100vh - 140px)