### PR TITLE
fix: change header navigation from projects to games

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ const navItems: NavItem[] = [
   { href: '/', labelKey: 'home' },
   { href: '/blog', labelKey: 'blog' },
   { href: '/tools', labelKey: 'tools' },
-  { href: '/projects', labelKey: 'projects' },
+  { href: '/games', labelKey: 'games' },
   { href: '/about', labelKey: 'about' },
 ];
 


### PR DESCRIPTION
The header was showing 'projects' link but should show 'games'
to match the actual games section that was added.