### PR TITLE
feat: translate blog UI to English

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -10,7 +10,7 @@ interface Props {
 
 const { title, description, date, slug, tags = [], image } = Astro.props;
 
-const formattedDate = date.toLocaleDateString('ko-KR', {
+const formattedDate = date.toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -31,6 +31,7 @@ const readingTime = Math.max(1, Math.ceil(wordCount / 200));
   image={post.data.image}
   type="article"
   publishedTime={post.data.date}
+  lang="en"
 >
   <article class="py-16 md:py-20 px-6">
     <div class="max-w-3xl mx-auto">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -13,7 +13,7 @@ export async function getStaticPaths() {
 const { post } = Astro.props;
 const { Content } = await post.render();
 
-const formattedDate = post.data.date.toLocaleDateString('ko-KR', {
+const formattedDate = post.data.date.toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
@@ -38,11 +38,11 @@ const readingTime = Math.max(1, Math.ceil(wordCount / 200));
       <header class="mb-10">
         <!-- Breadcrumb -->
         <nav class="flex items-center gap-2 text-sm text-[var(--color-text-muted)] mb-6">
-          <a href="/" class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">홈</a>
+          <a href="/" class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">Home</a>
           <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
           </svg>
-          <a href="/blog" class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">블로그</a>
+          <a href="/blog" class="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">Blog</a>
         </nav>
 
         <!-- Meta -->
@@ -54,7 +54,7 @@ const readingTime = Math.max(1, Math.ceil(wordCount / 200));
             {formattedDate}
           </time>
           <span class="text-sm text-[var(--color-text-muted)]">
-            {readingTime}분 소요
+            {readingTime} min read
           </span>
         </div>
 
@@ -109,7 +109,7 @@ const readingTime = Math.max(1, Math.ceil(wordCount / 200));
             <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
             </svg>
-            목록으로 돌아가기
+            Back to list
           </a>
 
           <div class="flex items-center gap-2">
@@ -120,7 +120,7 @@ const readingTime = Math.max(1, Math.ceil(wordCount / 200));
               <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
               </svg>
-              공유하기
+              Share
             </button>
 
             <button
@@ -130,7 +130,7 @@ const readingTime = Math.max(1, Math.ceil(wordCount / 200));
               <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
               </svg>
-              링크 복사
+              Copy link
             </button>
           </div>
         </div>
@@ -154,13 +154,13 @@ const readingTime = Math.max(1, Math.ceil(wordCount / 200));
       }
     } else {
       await navigator.clipboard.writeText(url);
-      showToast('링크가 복사되었습니다!');
+      showToast('Link copied!');
     }
   });
 
   copyBtn?.addEventListener('click', async () => {
     await navigator.clipboard.writeText(url);
-    showToast('링크가 복사되었습니다!');
+    showToast('Link copied!');
   });
 
   function showToast(message: string) {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -10,7 +10,7 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 const allTags = [...new Set(posts.flatMap(post => post.data.tags))].sort();
 ---
 
-<MainLayout title="Blog | Restato" description="Development logs, learnings, and thoughts.">
+<MainLayout title="Blog | Restato" description="Development logs, learnings, and thoughts." lang="en">
   <section class="py-20 px-6">
     <div class="max-w-4xl mx-auto">
       <!-- Header -->

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -10,15 +10,15 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
 const allTags = [...new Set(posts.flatMap(post => post.data.tags))].sort();
 ---
 
-<MainLayout title="Blog | Restato" description="개발 일지, 배운 것들, 그리고 생각들을 기록합니다.">
+<MainLayout title="Blog | Restato" description="Development logs, learnings, and thoughts.">
   <section class="py-20 px-6">
     <div class="max-w-4xl mx-auto">
       <!-- Header -->
       <div class="mb-12">
         <p class="text-sm font-medium text-primary-600 dark:text-primary-400 mb-2">Blog</p>
-        <h1 class="text-4xl font-bold mb-4">블로그</h1>
+        <h1 class="text-4xl font-bold mb-4">Blog</h1>
         <p class="text-lg text-[var(--color-text-muted)] max-w-xl">
-          개발하면서 배운 것들, 생각들, 그리고 삽질기를 기록합니다.
+          Development logs, learnings, thoughts, and coding adventures.
         </p>
       </div>
 
@@ -26,7 +26,7 @@ const allTags = [...new Set(posts.flatMap(post => post.data.tags))].sort();
       {allTags.length > 0 && (
         <div class="mb-10 pb-6 border-b border-[var(--color-border)]">
           <div class="flex flex-wrap gap-2 items-center">
-            <span class="text-sm font-medium text-[var(--color-text-muted)] mr-1">태그</span>
+            <span class="text-sm font-medium text-[var(--color-text-muted)] mr-1">Tags</span>
             {allTags.map(tag => (
               <a
                 href={`/blog/tag/${tag}`}
@@ -62,9 +62,9 @@ const allTags = [...new Set(posts.flatMap(post => post.data.tags))].sort();
               <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
             </svg>
           </div>
-          <h2 class="text-xl font-bold mb-2">아직 작성된 글이 없습니다</h2>
+          <h2 class="text-xl font-bold mb-2">No posts yet</h2>
           <p class="text-[var(--color-text-muted)]">
-            곧 첫 번째 글이 올라올 거예요!
+            The first post will be up soon!
           </p>
         </div>
       )}
@@ -72,7 +72,7 @@ const allTags = [...new Set(posts.flatMap(post => post.data.tags))].sort();
       <!-- Post count -->
       {posts.length > 0 && (
         <p class="mt-8 text-center text-sm text-[var(--color-text-muted)]">
-          총 {posts.length}개의 글
+          {posts.length} posts
         </p>
       )}
     </div>


### PR DESCRIPTION
Change all Korean texts to English in blog pages:
- Breadcrumb: 홈 > 블로그 → Home > Blog
- Reading time: 분 소요 → min read
- Buttons: 공유하기/링크 복사 → Share/Copy link
- Back link: 목록으로 돌아가기 → Back to list
- Tags label: 태그 → Tags
- Post count and empty state messages
- Date format: ko-KR → en-US