### PR TITLE
feat: add i18n support to tools page components

### DIFF
--- a/src/components/tools/FavoriteButton.tsx
+++ b/src/components/tools/FavoriteButton.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from '../../i18n/useTranslation';
 
 interface FavoriteButtonProps {
   slug: string;
@@ -40,6 +41,9 @@ export function toggleFavorite(slug: string): boolean {
 }
 
 export default function FavoriteButton({ slug, title, icon }: FavoriteButtonProps) {
+  const { t, translations } = useTranslation();
+  const tc = translations.tools.common;
+
   const [isFavorite, setIsFavorite] = useState(false);
   const [animate, setAnimate] = useState(false);
 
@@ -68,8 +72,8 @@ export default function FavoriteButton({ slug, title, icon }: FavoriteButtonProp
         }
         ${animate ? 'scale-110' : 'scale-100'}
       `}
-      aria-label={isFavorite ? '즐겨찾기 해제' : '즐겨찾기 추가'}
-      title={isFavorite ? '즐겨찾기에서 제거' : '즐겨찾기에 추가'}
+      aria-label={isFavorite ? t(tc.removeFromFavorite) : t(tc.addToFavorite)}
+      title={isFavorite ? t(tc.removeFromFavorite) : t(tc.addToFavorite)}
     >
       <svg
         className={`w-4 h-4 transition-transform ${animate ? 'scale-125' : ''}`}
@@ -84,7 +88,7 @@ export default function FavoriteButton({ slug, title, icon }: FavoriteButtonProp
           d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
         />
       </svg>
-      {isFavorite ? '즐겨찾기됨' : '즐겨찾기'}
+      {isFavorite ? t(tc.favorited) : t(tc.favorite)}
     </button>
   );
 }

--- a/src/components/tools/RelatedTools.astro
+++ b/src/components/tools/RelatedTools.astro
@@ -1,75 +1,47 @@
 ---
-interface Tool {
-  slug: string;
-  title: string;
-  description: string;
-  icon: string;
-  category: string;
-}
+import { toolsConfig, type Language } from '../../data/tools';
 
 interface Props {
   currentSlug: string;
   currentCategory: string;
+  lang?: Language;
 }
 
-const { currentSlug, currentCategory } = Astro.props;
+const { currentSlug, currentCategory, lang = 'ko' } = Astro.props;
 
-const allTools: Tool[] = [
-  // Generators
-  { slug: 'qr-code', title: 'QR 코드 생성기', description: 'URL이나 텍스트를 QR 코드로 변환', icon: '📱', category: 'generators' },
-  { slug: 'password', title: '비밀번호 생성기', description: '안전한 비밀번호 생성', icon: '🔐', category: 'generators' },
-  { slug: 'uuid', title: 'UUID 생성기', description: 'UUID v4 생성', icon: '🔑', category: 'generators' },
-  { slug: 'lorem-ipsum', title: 'Lorem Ipsum 생성기', description: '더미 텍스트 생성', icon: '📝', category: 'generators' },
-  { slug: 'color-palette', title: '색상 팔레트 생성기', description: '조화로운 색상 팔레트 생성', icon: '🎨', category: 'generators' },
-  { slug: 'hash', title: '해시 생성기', description: 'MD5, SHA-1, SHA-256 해시 생성', icon: '#️⃣', category: 'generators' },
-  // Converters
-  { slug: 'color', title: '색상 변환기', description: 'HEX, RGB, HSL 색상 변환', icon: '🌈', category: 'converters' },
-  { slug: 'unit', title: '단위 변환기', description: '길이, 무게, 온도 단위 변환', icon: '📏', category: 'converters' },
-  { slug: 'base64', title: 'Base64 인코더/디코더', description: '텍스트를 Base64로 인코딩/디코딩', icon: '🔄', category: 'converters' },
-  { slug: 'image-converter', title: '이미지 포맷 변환기', description: 'JPEG, PNG, WebP 포맷 간 변환', icon: '🖼️', category: 'image' },
-  // Text
-  { slug: 'text-counter', title: '텍스트 카운터', description: '글자수, 단어수, 줄수 세기', icon: '🔢', category: 'text' },
-  { slug: 'markdown', title: '마크다운 미리보기', description: '마크다운 실시간 미리보기', icon: '📄', category: 'text' },
-  { slug: 'diff', title: '텍스트 비교기', description: '두 텍스트의 차이점 비교', icon: '📊', category: 'developer' },
-  // Developer
-  { slug: 'json', title: 'JSON 포매터', description: 'JSON 포매팅 및 검증', icon: '{ }', category: 'developer' },
-  { slug: 'regex', title: '정규식 테스터', description: '정규식 테스트 및 매치 확인', icon: '🔍', category: 'developer' },
-  { slug: 'url-encoder', title: 'URL 인코더/디코더', description: 'URL 문자열 인코딩/디코딩', icon: '🔗', category: 'developer' },
-  { slug: 'jwt-decoder', title: 'JWT 디코더', description: 'JWT 토큰 디코딩 및 분석', icon: '🎫', category: 'developer' },
-  { slug: 'cron', title: 'Cron 표현식 생성기', description: 'Cron 표현식 생성 및 설명', icon: '⏰', category: 'developer' },
-  // Designer
-  { slug: 'gradient', title: 'CSS 그라데이션 생성기', description: 'CSS 그라데이션 시각적 생성', icon: '🌈', category: 'designer' },
-  { slug: 'box-shadow', title: 'CSS Box Shadow 생성기', description: 'CSS box-shadow 시각적 생성', icon: '🎭', category: 'designer' },
-  // Photographer
-  { slug: 'image-resizer', title: '이미지 리사이저', description: '이미지 크기 조절 및 압축', icon: '📐', category: 'image' },
-  { slug: 'exif', title: 'EXIF 정보 뷰어', description: '사진 EXIF 메타데이터 확인', icon: '📷', category: 'image' },
-  // Marketer
-  { slug: 'utm', title: 'UTM 링크 생성기', description: '캠페인 추적용 UTM 링크 생성', icon: '📊', category: 'marketer' },
-  // Productivity
-  { slug: 'timer', title: '타이머 / 스톱워치', description: '타이머와 스톱워치', icon: '⏱️', category: 'productivity' },
-  { slug: 'pomodoro', title: '포모도로 타이머', description: '포모도로 기법으로 생산성 향상', icon: '🍅', category: 'productivity' },
-  { slug: 'world-clock', title: '세계 시계', description: '전 세계 시간대 확인 및 변환', icon: '🌍', category: 'productivity' },
-];
+const translations = {
+  ko: '관련 도구',
+  en: 'Related Tools',
+  ja: '関連ツール',
+};
 
-// 같은 카테고리의 도구 우선, 그 다음 다른 카테고리
-const relatedTools = allTools
+const relatedTitle = translations[lang] || translations.ko;
+
+// Get tools from toolsConfig and filter related ones
+const relatedTools = toolsConfig
   .filter(tool => tool.slug !== currentSlug)
   .sort((a, b) => {
     if (a.category === currentCategory && b.category !== currentCategory) return -1;
     if (a.category !== currentCategory && b.category === currentCategory) return 1;
     return 0;
   })
-  .slice(0, 4);
+  .slice(0, 4)
+  .map(tool => ({
+    slug: tool.slug,
+    title: tool.seo[lang]?.title.split(' - ')[0] || tool.seo.ko.title.split(' - ')[0],
+    description: tool.seo[lang]?.description || tool.seo.ko.description,
+    icon: tool.icon,
+  }));
 ---
 
 <section class="mt-12 pt-8 border-t border-[var(--color-border)]">
   <h2 class="text-xl font-bold text-[var(--color-text)] mb-6 flex items-center gap-2">
-    <span>🔧</span> 관련 도구
+    <span>🔧</span> {relatedTitle}
   </h2>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     {relatedTools.map((tool) => (
       <a
-        href={`/tools/${tool.slug}`}
+        href={`/${lang}/tools/${tool.slug}`}
         class="group flex items-center gap-4 p-4 rounded-xl
           bg-[var(--color-card)] border border-[var(--color-border)]
           hover:border-primary-500 hover:shadow-md transition-all"

--- a/src/components/tools/ShareButton.tsx
+++ b/src/components/tools/ShareButton.tsx
@@ -1,44 +1,22 @@
 import { useState } from 'react';
-
-type Language = 'ko' | 'en' | 'ja';
-
-const translations = {
-  ko: {
-    share: '공유',
-    copied: '복사됨!',
-    copyLink: '링크 복사',
-    kakao: '카카오톡',
-  },
-  en: {
-    share: 'Share',
-    copied: 'Copied!',
-    copyLink: 'Copy Link',
-    kakao: 'KakaoTalk',
-  },
-  ja: {
-    share: 'シェア',
-    copied: 'コピー!',
-    copyLink: 'リンクコピー',
-    kakao: 'カカオトーク',
-  },
-};
+import { useTranslation } from '../../i18n/useTranslation';
 
 interface ShareButtonProps {
   title: string;
   description: string;
   url?: string;
-  lang?: Language;
 }
 
-export default function ShareButton({ title, description, url, lang = 'ko' }: ShareButtonProps) {
+export default function ShareButton({ title, description, url }: ShareButtonProps) {
+  const { t, translations } = useTranslation();
+  const tc = translations.tools.common;
+
   const [showDropdown, setShowDropdown] = useState(false);
   const [copied, setCopied] = useState(false);
-  const t = translations[lang];
 
   const shareUrl = url || (typeof window !== 'undefined' ? window.location.href : '');
   const encodedUrl = encodeURIComponent(shareUrl);
   const encodedTitle = encodeURIComponent(title);
-  const encodedDesc = encodeURIComponent(description);
 
   const copyLink = async () => {
     try {
@@ -125,14 +103,14 @@ export default function ShareButton({ title, description, url, lang = 'ko' }: Sh
           bg-[var(--color-card)] border border-[var(--color-border)]
           hover:border-primary-500 hover:text-primary-500
           transition-colors text-sm font-medium"
-        aria-label={t.share}
+        aria-label={t(tc.share)}
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
             d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
           />
         </svg>
-        {t.share}
+        {t(tc.share)}
       </button>
 
       {showDropdown && (
@@ -155,7 +133,7 @@ export default function ShareButton({ title, description, url, lang = 'ko' }: Sh
                   <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  <span className="text-green-500">{t.copied}</span>
+                  <span className="text-green-500">{t(tc.copied)}</span>
                 </>
               ) : (
                 <>
@@ -164,7 +142,7 @@ export default function ShareButton({ title, description, url, lang = 'ko' }: Sh
                       d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
                     />
                   </svg>
-                  {t.copyLink}
+                  {t(tc.copyLink)}
                 </>
               )}
             </button>
@@ -210,7 +188,7 @@ export default function ShareButton({ title, description, url, lang = 'ko' }: Sh
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 3c5.799 0 10.5 3.664 10.5 8.185 0 4.52-4.701 8.184-10.5 8.184a13.5 13.5 0 01-1.727-.11l-4.408 2.883c-.501.265-.678.236-.472-.413l.892-3.678c-2.88-1.46-4.785-3.99-4.785-6.866C1.5 6.665 6.201 3 12 3z"/>
               </svg>
-              {t.kakao}
+              KakaoTalk
             </button>
           </div>
         </>

--- a/src/i18n/translations/tools.ts
+++ b/src/i18n/translations/tools.ts
@@ -18,6 +18,14 @@ export const toolTranslations = {
     stop: { ko: '정지', en: 'Stop', ja: '停止' },
     pause: { ko: '일시정지', en: 'Pause', ja: '一時停止' },
     resume: { ko: '재개', en: 'Resume', ja: '再開' },
+    // RelatedTools, FavoriteButton, ShareButton
+    relatedTools: { ko: '관련 도구', en: 'Related Tools', ja: '関連ツール' },
+    favorite: { ko: '즐겨찾기', en: 'Favorite', ja: 'お気に入り' },
+    favorited: { ko: '즐겨찾기됨', en: 'Favorited', ja: 'お気に入り済み' },
+    addToFavorite: { ko: '즐겨찾기에 추가', en: 'Add to favorites', ja: 'お気に入りに追加' },
+    removeFromFavorite: { ko: '즐겨찾기에서 제거', en: 'Remove from favorites', ja: 'お気に入りから削除' },
+    share: { ko: '공유', en: 'Share', ja: '共有' },
+    copyLink: { ko: '링크 복사', en: 'Copy link', ja: 'リンクをコピー' },
   },
 
   // QR Code Generator

--- a/src/pages/[lang]/tools/[slug].astro
+++ b/src/pages/[lang]/tools/[slug].astro
@@ -268,7 +268,7 @@ const appSchema = {
     </div>
 
     <!-- Related Tools -->
-    <RelatedTools currentSlug={tool.slug} currentCategory={tool.category} />
+    <RelatedTools currentSlug={tool.slug} currentCategory={tool.category} lang={lang} />
 
     <!-- Info Section -->
     <section class="mt-8 p-6 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)]">


### PR DESCRIPTION
## Changes

- Add translation keys for RelatedTools, FavoriteButton, ShareButton to tools.ts
- Update FavoriteButton.tsx to use useTranslation hook
- Update ShareButton.tsx to use useTranslation hook (replace internal translations)
- Update RelatedTools.astro to accept lang prop and use toolsConfig for translated tool names
- Pass lang prop to RelatedTools in [slug].astro

## Supported Languages
- Korean (ko)
- English (en)
- Japanese (ja)

---
Auto-generated by /pr skill