### PR TITLE
feat: add whack-a-mole mini game

### DIFF
--- a/src/components/games/WhackAMole.tsx
+++ b/src/components/games/WhackAMole.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from '../../i18n/useTranslation';
+
+const GRID_SIZE = 9;
+const GAME_DURATION = 30;
+
+export default function WhackAMole() {
+  const { t } = useTranslation();
+  const [score, setScore] = useState(0);
+  const [bestScore, setBestScore] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(GAME_DURATION);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [moleIndex, setMoleIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('whack-a-mole-best');
+    if (saved) {
+      setBestScore(parseInt(saved, 10));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isPlaying) return;
+
+    const timer = setInterval(() => {
+      setTimeLeft(prev => {
+        if (prev <= 1) {
+          setIsPlaying(false);
+          setMoleIndex(null);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [isPlaying]);
+
+  useEffect(() => {
+    if (!isPlaying) return;
+
+    const moveMole = () => {
+      setMoleIndex(Math.floor(Math.random() * GRID_SIZE));
+    };
+
+    moveMole();
+    const moleTimer = setInterval(moveMole, 650);
+
+    return () => clearInterval(moleTimer);
+  }, [isPlaying]);
+
+  useEffect(() => {
+    if (!isPlaying && timeLeft === 0 && score > bestScore) {
+      setBestScore(score);
+      localStorage.setItem('whack-a-mole-best', score.toString());
+    }
+  }, [isPlaying, timeLeft, score, bestScore]);
+
+  const startGame = () => {
+    setScore(0);
+    setTimeLeft(GAME_DURATION);
+    setIsPlaying(true);
+  };
+
+  const hitMole = (index: number) => {
+    if (!isPlaying || moleIndex !== index) return;
+
+    setScore(prev => prev + 1);
+    setMoleIndex(Math.floor(Math.random() * GRID_SIZE));
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto">
+      <div className="grid grid-cols-3 gap-3 mb-6 text-center">
+        <div className="p-3 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)]">
+          <p className="text-xs text-[var(--color-text-muted)]">{t({ ko: '점수', en: 'Score', ja: 'スコア' })}</p>
+          <p className="text-2xl font-bold text-primary-500">{score}</p>
+        </div>
+        <div className="p-3 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)]">
+          <p className="text-xs text-[var(--color-text-muted)]">{t({ ko: '남은 시간', en: 'Time', ja: '残り時間' })}</p>
+          <p className="text-2xl font-bold text-orange-500">{timeLeft}</p>
+        </div>
+        <div className="p-3 rounded-xl bg-[var(--color-card)] border border-[var(--color-border)]">
+          <p className="text-xs text-[var(--color-text-muted)]">{t({ ko: '최고 기록', en: 'Best', ja: 'ベスト' })}</p>
+          <p className="text-2xl font-bold text-green-500">{bestScore}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 mb-6">
+        {Array.from({ length: GRID_SIZE }).map((_, index) => (
+          <button
+            key={index}
+            type="button"
+            onClick={() => hitMole(index)}
+            className="h-20 rounded-xl border border-[var(--color-border)] bg-[var(--color-card)] hover:border-primary-500 transition-colors"
+            aria-label={t({ ko: `${index + 1}번 구멍`, en: `Hole ${index + 1}`, ja: `${index + 1}番ホール` })}
+          >
+            <span className="text-3xl">{moleIndex === index ? '🐹' : '🕳️'}</span>
+          </button>
+        ))}
+      </div>
+
+      <div className="text-center">
+        {!isPlaying && timeLeft > 0 && (
+          <p className="text-[var(--color-text-muted)] mb-4">
+            {t({ ko: '30초 동안 두더지를 최대한 많이 잡아보세요!', en: 'Catch as many moles as you can in 30 seconds!', ja: '30秒でできるだけ多くモグラを捕まえよう！' })}
+          </p>
+        )}
+
+        {!isPlaying && timeLeft === 0 && (
+          <p className="text-lg font-bold mb-4">
+            {t({ ko: '게임 종료!', en: 'Time Up!', ja: 'ゲーム終了！' })} {t({ ko: '최종 점수', en: 'Final Score', ja: '最終スコア' })}: {score}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={startGame}
+          className="px-6 py-3 bg-primary-500 text-white rounded-xl font-bold hover:bg-primary-600 transition-colors"
+        >
+          {isPlaying
+            ? t({ ko: '다시 시작', en: 'Restart', ja: 'リスタート' })
+            : t({ ko: '게임 시작', en: 'Start Game', ja: 'ゲーム開始' })}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/games/WhackAMole.tsx
+++ b/src/components/games/WhackAMole.tsx
@@ -103,7 +103,11 @@ export default function WhackAMole() {
       <div className="text-center">
         {!isPlaying && timeLeft > 0 && (
           <p className="text-[var(--color-text-muted)] mb-4">
-            {t({ ko: '30초 동안 두더지를 최대한 많이 잡아보세요!', en: 'Catch as many moles as you can in 30 seconds!', ja: '30秒でできるだけ多くモグラを捕まえよう！' })}
+            {t({
+              ko: `${GAME_DURATION}초 동안 두더지를 최대한 많이 잡아보세요!`,
+              en: `Catch as many moles as you can in ${GAME_DURATION} seconds!`,
+              ja: `${GAME_DURATION}秒でできるだけ多くモグラを捕まえよう！`,
+            })}
           </p>
         )}
 

--- a/src/components/games/WhackAMole.tsx
+++ b/src/components/games/WhackAMole.tsx
@@ -63,10 +63,16 @@ export default function WhackAMole() {
   };
 
   const hitMole = (index: number) => {
-    if (!isPlaying || moleIndex !== index) return;
+    if (!isPlaying) return;
 
-    setScore(prev => prev + 1);
-    setMoleIndex(Math.floor(Math.random() * GRID_SIZE));
+    setMoleIndex(prevIndex => {
+      if (prevIndex !== index) {
+        return prevIndex;
+      }
+
+      setScore(prev => prev + 1);
+      return Math.floor(Math.random() * GRID_SIZE);
+    });
   };
 
   return (

--- a/src/data/__tests__/games.test.ts
+++ b/src/data/__tests__/games.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { gamesConfig, getGameConfig, getGamesByCategory, getFeaturedGames } from '../games';
+
+describe('games config', () => {
+  it('includes whack-a-mole game metadata', () => {
+    const game = getGameConfig('whack-a-mole');
+
+    expect(game).toBeDefined();
+    expect(game?.category).toBe('arcade');
+    expect(game?.featured).toBe(true);
+    expect(game?.seo.ko.title).toContain('두더지 잡기');
+  });
+
+  it('returns whack-a-mole in arcade and featured lists', () => {
+    const arcadeSlugs = getGamesByCategory('arcade').map(game => game.slug);
+    const featuredSlugs = getFeaturedGames().map(game => game.slug);
+
+    expect(arcadeSlugs).toContain('whack-a-mole');
+    expect(featuredSlugs).toContain('whack-a-mole');
+  });
+
+  it('keeps unique slugs', () => {
+    const slugs = gamesConfig.map(game => game.slug);
+    const unique = new Set(slugs);
+
+    expect(unique.size).toBe(slugs.length);
+  });
+});

--- a/src/data/games.ts
+++ b/src/data/games.ts
@@ -248,6 +248,29 @@ export const gamesConfig: GameConfig[] = [
       },
     },
   },
+  {
+    slug: 'whack-a-mole',
+    icon: '🔨',
+    category: 'arcade',
+    featured: true,
+    seo: {
+      ko: {
+        title: '두더지 잡기 - 무료 온라인 순발력 게임',
+        description: '무료 온라인 두더지 잡기 게임. 30초 동안 최대한 많이 두더지를 잡아 점수를 올려보세요.',
+        keywords: ['두더지 잡기', '순발력 게임', '클릭 게임', ...seoKeywords.ko],
+      },
+      en: {
+        title: 'Whack-a-Mole - Free Online Reflex Game',
+        description: 'Free online whack-a-mole game. Catch as many moles as possible in 30 seconds.',
+        keywords: ['whack a mole', 'reflex game', 'click game', ...seoKeywords.en],
+      },
+      ja: {
+        title: 'モグラたたき - 無料オンライン反射神経ゲーム',
+        description: '無料オンラインモグラたたきゲーム。30秒でできるだけ多くモグラを叩いてスコアを伸ばそう。',
+        keywords: ['モグラたたき', '反射神経ゲーム', 'クリックゲーム', ...seoKeywords.ja],
+      },
+    },
+  },
   // Event/Raffle Games
   {
     slug: 'roulette',

--- a/src/pages/[lang]/games/[slug].astro
+++ b/src/pages/[lang]/games/[slug].astro
@@ -15,6 +15,7 @@ import Minesweeper from '../../../components/games/Minesweeper';
 import TicTacToe from '../../../components/games/TicTacToe';
 import ColorMatch from '../../../components/games/ColorMatch';
 import MathQuiz from '../../../components/games/MathQuiz';
+import WhackAMole from '../../../components/games/WhackAMole';
 import LadderGame from '../../../components/games/LadderGame';
 import TeamRandomizer from '../../../components/games/TeamRandomizer';
 import BingoGame from '../../../components/games/BingoGame';
@@ -163,6 +164,7 @@ const gameSchema = {
         {slug === 'tic-tac-toe' && <TicTacToe client:load />}
         {slug === 'color-match' && <ColorMatch client:load />}
         {slug === 'math-quiz' && <MathQuiz client:load />}
+        {slug === 'whack-a-mole' && <WhackAMole client:load />}
         {slug === 'ladder' && <LadderGame client:load />}
         {slug === 'team-randomizer' && <TeamRandomizer client:load />}
         {slug === 'bingo' && <BingoGame client:load />}


### PR DESCRIPTION
### Motivation
- Add a quick, replayable browser mini-game that users are likely to play frequently (Whack-a-Mole). 
- Integrate the new game into the existing games collection so it appears in listings, static routes, and SEO data. 
- Keep implementation consistent with existing patterns (translations, localStorage high score, client-loaded React components). 

### Description
- Added `src/components/games/WhackAMole.tsx`, a 3x3 interactive board with a 30-second timer, scoring, best-score persisted to `localStorage`, and ko/en/ja UI strings via the existing translation helper. 
- Registered the new slug `whack-a-mole` in `src/data/games.ts` with icon, `category: 'arcade'`, `featured: true`, and multilingual SEO metadata. 
- Wired the component into the dynamic game route by importing and rendering it in `src/pages/[lang]/games/[slug].astro`, and added `src/data/__tests__/games.test.ts` to cover the new game metadata and slug uniqueness. 

### Testing
- Ran `npm run test -- src/data/__tests__/games.test.ts --run` and the test file passed (3 tests). 
- Ran `npm run build` and the site build completed successfully with sitemaps generated. 
- Created an automated page preview screenshot of `/ko/games/whack-a-mole` during dev preview to verify rendering (artifact captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993f498e2e0832e8de269868ee6e507)