### PR TITLE
blog: add Korean food commerce embedding tokenizer strategy post

### DIFF
--- a/src/content/blog/korean-food-commerce-embedding-tokenizer-strategy.mdx
+++ b/src/content/blog/korean-food-commerce-embedding-tokenizer-strategy.mdx
@@ -1,0 +1,364 @@
+---
+title: "How to Build and Operate a Company-Owned Embedding Tokenizer for Korean Food Commerce"
+description: "An end-to-end methodology for owning tokenizer and embedding capabilities in Korean food commerce: model strategy, data flywheel, evaluation metrics, platform delivery, and sustainability through feedback loops."
+date: 2026-02-25
+tags: ["korean-nlp", "embedding", "tokenizer", "food-commerce", "mlops", "retrieval", "recommendation"]
+---
+
+If your company wants to own a tokenizer + embedding stack (instead of renting intelligence from external APIs), you are making a strategic infrastructure decision, not just a model choice.
+
+In Korean food commerce, this matters even more because product language is noisy, compositional, and fast-changing:
+- mixed scripts (Korean + English + numbers),
+- brand-heavy surface forms,
+- shorthand and misspellings in search,
+- short shelf-life trends,
+- and intent hidden in tiny lexical differences (e.g., gift intent vs. household refill intent).
+
+This guide presents an **ultra-practical operating model**: how to build, offer, measure, and continuously improve a company-owned embedding tokenizer system for Korean food commerce.
+
+---
+
+## 1) Why Own the Tokenizer and Embedding Layer?
+
+Most teams discuss “which embedding model to use.” The stronger question is:
+
+> Which parts of semantic understanding should be your company’s compounding asset?
+
+Owning the stack gives you:
+
+1. **Domain control**
+   - You encode Korean food-commerce vocabulary exactly as your business sees it (brands, options, pack sizes, freshness, dietary filters, seasonal terms).
+2. **Cost control at scale**
+   - High-query traffic (search, recommendation, similarity, ad retrieval) makes per-request API pricing expensive over time.
+3. **Latency and reliability control**
+   - On-prem or VPC inference removes third-party dependency for critical retrieval paths.
+4. **Governance and privacy**
+   - Sensitive merchant and user interaction data stays inside your trust boundary.
+5. **Faster product iteration**
+   - You can retrain and redeploy for category events (e.g., Chuseok gifting, kimchi season, health trend spikes) without external roadmap constraints.
+
+---
+
+## 2) Reference Architecture (Tokenizer + Embedding as a Platform)
+
+Treat this as a productized internal platform with clear interfaces.
+
+### Core Components
+
+1. **Tokenizer Service**
+   - Versioned tokenizer artifacts (`tok-v1`, `tok-v2`...)
+   - Fast online encoding endpoint + offline batch encoding tooling
+   - OOV / unknown-token monitoring
+
+2. **Embedding Model Service**
+   - Versioned embedding models (`emb-v1`, `emb-v2`...)
+   - Multi-input support: query, product title, attributes, reviews, merchant metadata
+   - Separate towers optional (query tower / item tower) for retrieval optimization
+
+3. **Vector Index Layer**
+   - ANN index for products, merchants, collections, recipes
+   - Namespace by locale/domain/time window
+   - Freshness-aware partial reindexing
+
+4. **Evaluation & Governance Layer**
+   - Offline benchmark harness
+   - Online A/B and interleaving experiments
+   - Drift and degradation alarms
+
+5. **Feature & Feedback Pipeline**
+   - Event logs (search query → click/cart/order)
+   - Hard negative mining
+   - Labeling loop for semantic relevance and substitution behavior
+
+---
+
+## 3) Methodology: Build in Four Phases
+
+## Phase A — Scope and Success Contract (2–4 weeks)
+
+Define the exact business surfaces your embeddings must power:
+- Search retrieval
+- Similar products / substitution
+- Basket completion recommendations
+- Intent classification and routing
+
+Write a **success contract** before training:
+- Target latency (P95 end-to-end retrieval)
+- Target relevance gains (NDCG@10, Recall@50)
+- Target business lift (CTR, add-to-cart rate, conversion, AOV)
+- Target unit economics (cost per 1K embeddings, infra utilization)
+
+No success contract = endless model iteration with unclear ROI.
+
+## Phase B — Data Foundation and Tokenizer Strategy (4–8 weeks)
+
+### Data Layers to Build
+1. **Catalog semantics**
+   - title, brand, category, origin, weight/volume, price tier, storage type, dietary tags
+2. **Behavioral semantics**
+   - query → click, click → cart, cart → order, reorder cadence
+3. **Linguistic normalization**
+   - unit normalization (`g`, `kg`, `ml`, `L`), pack notation (`2+1`, `1+1`), spelling variants
+4. **Commercial context**
+   - promotion windows, stockout signals, seasonality tags
+
+### Tokenizer Design Choices
+
+For Korean food commerce, start with an experimental matrix:
+- Subword baseline (SentencePiece/BPE/Unigram variants)
+- Korean-aware segmentation hybrids (morpheme-informed pretokenization + subword)
+- Numeric and unit-preserving rules
+
+Important tokenizer KPIs:
+- OOV proxy rate by surface (query/catalog/reviews)
+- Token length efficiency (avg tokens per query/item)
+- Semantic fragmentation rate for critical entities (brands, product options)
+
+A tokenizer is successful when it **reduces semantic breakage without inflating sequence length excessively**.
+
+## Phase C — Embedding Model Development (6–12 weeks)
+
+Training curriculum:
+1. **Stage 1: Contrastive pretraining on in-domain pairs**
+   - positives: query-clicked item, co-bought pairs, substitutable pairs
+   - negatives: random + hard negatives from nearest-neighbor confusion
+2. **Stage 2: Supervised relevance fine-tuning**
+   - labeled judgments from merchandisers + search quality reviewers
+3. **Stage 3: Distillation / compression**
+   - optimize for online latency while preserving ranking quality
+
+Model family suggestions:
+- Start from multilingual encoder checkpoints with strong Korean support
+- Evaluate dual-encoder for retrieval and optional cross-encoder reranker for top-k refinement
+
+Output strategy:
+- 256/384/768 dimensional candidates depending on latency-memory tradeoff
+- INT8/FP16 serving variants for infra flexibility
+
+## Phase D — Productization and Rollout (ongoing)
+
+Roll out by traffic slices:
+1. One category first (e.g., fresh produce)
+2. Then high-value categories (gift sets, premium meat, health foods)
+3. Then long-tail categories
+
+Operate with canary + rollback from day one.
+
+---
+
+## 4) How to Offer It Internally (Service Model)
+
+Think of “embedding capability” as an internal API product.
+
+### Internal Product Packaging
+
+1. **Online APIs**
+   - `POST /embed/query`
+   - `POST /embed/item`
+   - `POST /similarity/search`
+
+2. **Offline SDK / Batch Jobs**
+   - nightly re-embedding pipeline
+   - category-level index rebuild utilities
+
+3. **Versioning and Compatibility**
+   - explicit model/tokenizer version in every response
+   - deprecation policy with migration windows
+
+4. **SLOs**
+   - availability, P95 latency, throughput ceilings, freshness lag
+
+5. **Consumer Playbooks**
+   - how search team integrates retrieval
+   - how recommendation team uses item-item vectors
+   - how merchandising team audits semantic neighbors
+
+---
+
+## 5) How to Tell the Performance Story (Executive + Operator Views)
+
+Don’t report only “embedding quality improved.” Tell a multi-layer performance story.
+
+### A. Model/IR Quality Metrics
+- Recall@K, NDCG@K, MRR
+- Query intent slice performance (brand intent, ingredient intent, meal-planning intent)
+- Out-of-distribution query robustness
+
+### B. Product Funnel Metrics
+- Search CTR
+- Add-to-cart rate from search/recommendation surfaces
+- Conversion rate
+- Basket size / AOV
+- Substitution success under stockouts
+
+### C. Unit Economics
+- Cost per 1K inference requests
+- Cost per 1K index updates
+- Infra utilization (GPU/CPU memory, QPS headroom)
+
+### D. Reliability Metrics
+- P95/P99 latency
+- Timeout/error rates
+- Index freshness SLA adherence
+
+### E. Strategic Asset Metrics
+- Coverage of taxonomy and merchants
+- Time-to-adapt for new seasonal terms
+- Ratio of traffic served by in-house embeddings vs. fallback baselines
+
+A good narrative format:
+1. baseline,
+2. intervention,
+3. measured lift,
+4. confidence interval / significance,
+5. operational tradeoff,
+6. next iteration hypothesis.
+
+---
+
+## 6) Feedback Loop for Sustainability (Data Flywheel Design)
+
+To keep the model relevant, your feedback loop must be engineered, not symbolic.
+
+### Closed-Loop Design
+1. **Capture**
+   - log every retrieval candidate set, ranking position, and user action
+2. **Diagnose**
+   - detect failure buckets: lexical miss, attribute mismatch, intent mismatch, cold-start miss
+3. **Label**
+   - combine implicit labels (click/cart/order) with targeted human labels for ambiguous cases
+4. **Retrain**
+   - scheduled fine-tuning + event-triggered refresh (seasonal campaign spikes)
+5. **Re-evaluate**
+   - run fixed benchmark suite + shadow tests before production promotion
+6. **Release**
+   - canary deployment with real-time guardrails
+
+### Sustainability Guardrails
+- Prevent feedback loops from amplifying popularity bias:
+  - include exploration traffic,
+  - reweight long-tail positive signals,
+  - audit fairness across merchant sizes.
+- Prevent data poisoning:
+  - anomaly detection for bot-like query-click bursts,
+  - trust scoring for feedback sources.
+- Prevent model drift blindness:
+  - weekly drift report by intent segment and category.
+
+---
+
+## 7) Korean Food Commerce-Specific Strategy
+
+This domain has unique linguistic and commercial features. Bake them in from the start.
+
+### A. Language and Tokenization Nuances
+- Handle mixed-script entities (Korean + English brand names).
+- Preserve unit semantics (`500g`, `1kg`, `2L`) as first-class signals.
+- Normalize colloquial abbreviations and spacing variants.
+- Protect option semantics (“sliced”, “boneless”, “low-sodium”, “gift box”).
+
+### B. Catalog Dynamics
+- High SKU churn from promotions and seasonality requires rapid re-embedding.
+- Category-specific embedding heads can help for difficult verticals (e.g., seafood freshness vs. snack flavor taxonomy).
+
+### C. Intent Taxonomy for Korean Grocery/Food
+Define and monitor key intent buckets:
+- exact brand/product recall,
+- ingredient discovery,
+- health/diet constraints,
+- gifting intent,
+- price-value hunting,
+- meal-prep convenience.
+
+### D. Offline Dataset Curation Blueprint
+Build benchmark slices that mirror business-critical scenarios:
+- normal queries,
+- typo/spacing variants,
+- seasonal terms,
+- substitution under stockout,
+- long-tail local brand queries,
+- mixed-language queries.
+
+---
+
+## 8) Suggested KPI Tree (From Tokenizer to Revenue)
+
+**Tokenizer Layer**
+- token efficiency
+- semantic fragmentation rate
+- unknown-token rate trend
+
+**Retrieval Layer**
+- Recall@50
+- NDCG@10
+- hard-query win rate
+
+**Ranking/Product Layer**
+- CTR uplift
+- add-to-cart uplift
+- GMV impact from search/reco surfaces
+
+**Ops Layer**
+- P95 latency
+- infra cost/query
+- incident count and MTTR
+
+**Strategic Layer**
+- in-house semantic coverage ratio
+- model refresh cycle time
+- dependency reduction on external APIs
+
+This tree helps executives and engineers stay aligned on the same operating truth.
+
+---
+
+## 9) 12-Month Execution Roadmap (Pragmatic)
+
+### Quarter 1
+- Define success contract and data inventory
+- Build tokenizer experiments and baseline embedding benchmarks
+- Launch first retrieval pilot in one category
+
+### Quarter 2
+- Productionize embedding API + monitoring
+- Add hard-negative mining and human relevance labeling
+- Expand to top GMV categories
+
+### Quarter 3
+- Optimize latency/cost (quantization, index tuning)
+- Introduce seasonal retraining cadence
+- Launch semantic analytics dashboards for product and merchandising teams
+
+### Quarter 4
+- Mature governance (model cards, release checklists, rollback automation)
+- Expand multilingual handling for imported brands and cross-border assortments
+- Set next-year targets based on proven ROI
+
+---
+
+## 10) Common Failure Patterns (and Fixes)
+
+1. **Failure: Great offline metrics, weak online lift**
+   - Fix: align offline dataset with real funnel bottlenecks and segment by intent.
+
+2. **Failure: Tokenizer upgrades break backward compatibility**
+   - Fix: strict versioning + dual-run migration window.
+
+3. **Failure: Head queries improve, long-tail degrades**
+   - Fix: long-tail reweighting + exploration traffic + long-tail benchmark gating.
+
+4. **Failure: Embedding system becomes “ML-only” silo**
+   - Fix: shared KPI ownership across search, recommendation, merchandising, and platform.
+
+---
+
+## Final Takeaway
+
+Owning a tokenizer + embedding stack in Korean food commerce is not just about building a better vector.
+It is about building a **semantic operating system** for your company:
+- domain-adapted language understanding,
+- measurable commercial outcomes,
+- resilient MLOps,
+- and a durable feedback flywheel that compounds over time.
+
+If you execute with strong methodology, disciplined metrics, and a real feedback loop, your in-house embedding capability becomes both a performance engine and a strategic moat.


### PR DESCRIPTION
### Motivation
- Provide an in-depth, actionable English guide for teams that want to own tokenizer + embedding capabilities specifically for Korean food commerce, covering model, data, evaluation, productization, and sustainability.;
- Surface a practical operating playbook (architecture, KPIs, feedback loop, and a 12-month roadmap) to help engineering and product teams make a measured investment decision rather than ad-hoc experimentation.

### Description
- Added a new MDX blog post at `src/content/blog/korean-food-commerce-embedding-tokenizer-strategy.mdx` that explains reference architecture, tokenizer design choices, training curriculum, internal service packaging, KPI tree, feedback-loop design, and domain-specific considerations for Korean food commerce.
- The content includes concrete metrics and SLAs to tell the performance story (model/IR quality, funnel metrics, unit economics, reliability, and strategic asset metrics) and prescriptive rollout phases and failure-mode mitigations.
- This change is content-only and does not modify application code paths, APIs, or data artifacts beyond the new blog entry.

### Testing
- Ran `npm run build:astro` to validate the site build and static page generation, which completed successfully and produced the `dist/` output and sitemap.;
- Launched the dev server and exercised the new page with an automated Playwright script to capture a screenshot of `/blog/korean-food-commerce-embedding-tokenizer-strategy/`, which completed successfully as a smoke-check of page rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee53485d8832e93fd2c13a79e1134)