### PR TITLE
blog: add practical Post-Training guide for LLMs (equations, code, diagrams)

### DIFF
--- a/public/images/blog/posttraining-explained/posttraining-pipeline.svg
+++ b/public/images/blog/posttraining-explained/posttraining-pipeline.svg
@@ -1,0 +1,49 @@
+<svg width="1200" height="620" viewBox="0 0 1200 620" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Post-training pipeline overview</title>
+  <desc id="desc">A simple flow diagram showing SFT, preference tuning, and safety checks feeding into deployment.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="8" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#cbd5e1" />
+    </marker>
+  </defs>
+
+  <rect width="1200" height="620" fill="url(#bg)" rx="20"/>
+  <text x="600" y="70" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="38" fill="#e2e8f0" font-weight="700">Post-Training in Practice</text>
+  <text x="600" y="105" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="20" fill="#94a3b8">How a base model becomes useful, aligned, and production-ready</text>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <rect x="70" y="180" width="220" height="240" rx="18" fill="#1d4ed8" opacity="0.92"/>
+    <text x="180" y="235" text-anchor="middle" font-size="26" fill="#eff6ff" font-weight="700">1) SFT</text>
+    <text x="180" y="275" text-anchor="middle" font-size="18" fill="#dbeafe">Curated instructions</text>
+    <text x="180" y="302" text-anchor="middle" font-size="18" fill="#dbeafe">+ high-quality answers</text>
+    <text x="180" y="350" text-anchor="middle" font-size="16" fill="#bfdbfe">Goal: teach format</text>
+
+    <rect x="350" y="180" width="220" height="240" rx="18" fill="#7c3aed" opacity="0.92"/>
+    <text x="460" y="235" text-anchor="middle" font-size="26" fill="#f5f3ff" font-weight="700">2) Preference</text>
+    <text x="460" y="275" text-anchor="middle" font-size="18" fill="#ede9fe">Ranked outputs</text>
+    <text x="460" y="302" text-anchor="middle" font-size="18" fill="#ede9fe">or reward model</text>
+    <text x="460" y="350" text-anchor="middle" font-size="16" fill="#ddd6fe">Goal: pick better answers</text>
+
+    <rect x="630" y="180" width="220" height="240" rx="18" fill="#0f766e" opacity="0.92"/>
+    <text x="740" y="235" text-anchor="middle" font-size="26" fill="#ecfeff" font-weight="700">3) Safety</text>
+    <text x="740" y="275" text-anchor="middle" font-size="18" fill="#ccfbf1">Policy datasets</text>
+    <text x="740" y="302" text-anchor="middle" font-size="18" fill="#ccfbf1">+ adversarial tests</text>
+    <text x="740" y="350" text-anchor="middle" font-size="16" fill="#99f6e4">Goal: reduce harmful outputs</text>
+
+    <rect x="910" y="180" width="220" height="240" rx="18" fill="#b45309" opacity="0.92"/>
+    <text x="1020" y="235" text-anchor="middle" font-size="26" fill="#fffbeb" font-weight="700">4) Deploy</text>
+    <text x="1020" y="275" text-anchor="middle" font-size="18" fill="#fef3c7">Eval gates</text>
+    <text x="1020" y="302" text-anchor="middle" font-size="18" fill="#fef3c7">+ monitoring</text>
+    <text x="1020" y="350" text-anchor="middle" font-size="16" fill="#fde68a">Goal: stable production</text>
+  </g>
+
+  <line x1="290" y1="300" x2="340" y2="300" stroke="#cbd5e1" stroke-width="5" marker-end="url(#arrow)"/>
+  <line x1="570" y1="300" x2="620" y2="300" stroke="#cbd5e1" stroke-width="5" marker-end="url(#arrow)"/>
+  <line x1="850" y1="300" x2="900" y2="300" stroke="#cbd5e1" stroke-width="5" marker-end="url(#arrow)"/>
+
+  <text x="600" y="535" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="18" fill="#cbd5e1">Core principle: improve capability and behavior together, then protect quality with evaluation gates.</text>
+</svg>

--- a/public/images/blog/posttraining-explained/posttraining-tradeoff-chart.svg
+++ b/public/images/blog/posttraining-explained/posttraining-tradeoff-chart.svg
@@ -1,0 +1,53 @@
+<svg width="1100" height="640" viewBox="0 0 1100 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Post-training progress chart</title>
+  <desc id="desc">A line chart showing helpfulness, harmlessness, and latency across post-training stages.</desc>
+  <rect width="1100" height="640" fill="#0b1020" rx="16"/>
+
+  <g font-family="Inter, Arial, sans-serif" fill="#dbeafe">
+    <text x="550" y="54" text-anchor="middle" font-size="32" font-weight="700">Example Quality Trend Across Post-Training Stages</text>
+    <text x="550" y="84" text-anchor="middle" font-size="17" fill="#94a3b8">Higher is better for quality metrics; lower is better for latency.</text>
+  </g>
+
+  <g stroke="#334155" stroke-width="1">
+    <line x1="120" y1="140" x2="120" y2="530"/>
+    <line x1="120" y1="530" x2="980" y2="530"/>
+    <line x1="120" y1="452" x2="980" y2="452"/>
+    <line x1="120" y1="374" x2="980" y2="374"/>
+    <line x1="120" y1="296" x2="980" y2="296"/>
+    <line x1="120" y1="218" x2="980" y2="218"/>
+    <line x1="120" y1="140" x2="980" y2="140"/>
+  </g>
+
+  <g font-family="Inter, Arial, sans-serif" font-size="14" fill="#94a3b8">
+    <text x="90" y="535">0</text>
+    <text x="78" y="457">20</text>
+    <text x="78" y="379">40</text>
+    <text x="78" y="301">60</text>
+    <text x="78" y="223">80</text>
+    <text x="70" y="145">100</text>
+  </g>
+
+  <g font-family="Inter, Arial, sans-serif" font-size="15" fill="#cbd5e1">
+    <text x="170" y="565" text-anchor="middle">Base</text>
+    <text x="380" y="565" text-anchor="middle">SFT</text>
+    <text x="590" y="565" text-anchor="middle">Preference</text>
+    <text x="800" y="565" text-anchor="middle">Safety Tune</text>
+    <text x="940" y="565" text-anchor="middle">Final</text>
+  </g>
+
+  <polyline points="170,428 380,312 590,226 800,187 940,171" fill="none" stroke="#38bdf8" stroke-width="5"/>
+  <polyline points="170,470 380,382 590,296 800,218 940,202" fill="none" stroke="#22c55e" stroke-width="5"/>
+  <polyline points="170,265 380,289 590,319 800,343 940,358" fill="none" stroke="#f59e0b" stroke-width="5"/>
+
+  <g>
+    <circle cx="170" cy="428" r="7" fill="#38bdf8"/><circle cx="380" cy="312" r="7" fill="#38bdf8"/><circle cx="590" cy="226" r="7" fill="#38bdf8"/><circle cx="800" cy="187" r="7" fill="#38bdf8"/><circle cx="940" cy="171" r="7" fill="#38bdf8"/>
+    <circle cx="170" cy="470" r="7" fill="#22c55e"/><circle cx="380" cy="382" r="7" fill="#22c55e"/><circle cx="590" cy="296" r="7" fill="#22c55e"/><circle cx="800" cy="218" r="7" fill="#22c55e"/><circle cx="940" cy="202" r="7" fill="#22c55e"/>
+    <circle cx="170" cy="265" r="7" fill="#f59e0b"/><circle cx="380" cy="289" r="7" fill="#f59e0b"/><circle cx="590" cy="319" r="7" fill="#f59e0b"/><circle cx="800" cy="343" r="7" fill="#f59e0b"/><circle cx="940" cy="358" r="7" fill="#f59e0b"/>
+  </g>
+
+  <g font-family="Inter, Arial, sans-serif" font-size="15">
+    <rect x="170" y="104" width="16" height="16" fill="#38bdf8"/><text x="194" y="117" fill="#dbeafe">Helpfulness score</text>
+    <rect x="380" y="104" width="16" height="16" fill="#22c55e"/><text x="404" y="117" fill="#dbeafe">Harmlessness score</text>
+    <rect x="625" y="104" width="16" height="16" fill="#f59e0b"/><text x="649" y="117" fill="#dbeafe">Latency (normalized, lower is better)</text>
+  </g>
+</svg>

--- a/src/content/blog/posttraining-explained-for-developers.mdx
+++ b/src/content/blog/posttraining-explained-for-developers.mdx
@@ -1,0 +1,159 @@
+---
+title: 'Post-Training for LLMs: A Simple, Practical Guide for Developers'
+description: 'An easy-to-understand guide to post-training with equations, code, charts, and workflow diagrams for real-world engineering teams.'
+date: 2026-02-25
+tags: ['llm', 'posttraining', 'machine-learning', 'ai-engineering', 'developer-guide']
+---
+
+If pretraining gives a model raw language ability, **post-training** teaches it to behave like a useful assistant.
+
+In plain words, post-training is where we make a base model:
+- follow instructions,
+- prefer better answers,
+- avoid unsafe behavior,
+- and stay reliable under production constraints.
+
+![Post-training pipeline overview](/images/blog/posttraining-explained/posttraining-pipeline.svg)
+
+## 1) What Is Post-Training?
+
+A practical post-training stack usually has three stages:
+
+1. **Supervised Fine-Tuning (SFT)**
+   - Train on prompt-response pairs written or curated by humans.
+2. **Preference Optimization**
+   - Train the model to choose preferred outputs (e.g., DPO, PPO/RLHF variants).
+3. **Safety + Robustness Tuning**
+   - Add policy/safety datasets and adversarial evaluations.
+
+A concise objective view:
+
+```text
+L_total = L_sft + λ_pref * L_pref + λ_safe * L_safe
+```
+
+Where:
+- `L_sft` teaches instruction following,
+- `L_pref` pushes the model toward preferred responses,
+- `L_safe` penalizes unsafe or policy-violating behavior,
+- and `λ` values control trade-offs.
+
+## 2) The Core Equations (No PhD Required)
+
+### 2.1 SFT Loss (token cross-entropy)
+
+```text
+L_sft = - Σ_t log p_θ(y_t | x, y_<t)
+```
+
+Intuition: maximize probability of the correct next token in the reference answer.
+
+### 2.2 Preference Loss (DPO-style intuition)
+
+For a prompt `x`, preferred answer `y+`, rejected answer `y-`:
+
+```text
+L_pref = - log σ(β * [log π_θ(y+|x) - log π_θ(y-|x)
+                      - log π_ref(y+|x) + log π_ref(y-|x)])
+```
+
+Intuition: make preferred answers relatively more likely than rejected ones while staying anchored to a reference policy.
+
+### 2.3 Safety-Constrained Objective
+
+```text
+maximize   Helpfulness(θ)
+subject to UnsafeRate(θ) ≤ ε
+```
+
+Intuition: we do not only maximize quality; we enforce safety constraints.
+
+## 3) A Production Workflow (Mermaid)
+
+```mermaid
+flowchart TD
+A[Base model checkpoint] --> B[SFT on instruction data]
+B --> C[Preference optimization DPO/RLHF]
+C --> D[Safety tuning and red-team data]
+D --> E[Evaluation gates]
+E -->|pass| F[Deploy]
+E -->|fail| G[Data/model iteration]
+G --> B
+```
+
+## 4) Minimal Training Code Example (PyTorch-style)
+
+```python
+import torch
+import torch.nn.functional as F
+
+# logits: [batch, seq, vocab], labels: [batch, seq]
+def sft_loss(logits, labels, ignore_index=-100):
+    vocab = logits.size(-1)
+    return F.cross_entropy(
+        logits.view(-1, vocab),
+        labels.view(-1),
+        ignore_index=ignore_index,
+    )
+
+# logp_chosen / logp_rejected: [batch]
+def dpo_loss(logp_chosen, logp_rejected, ref_chosen, ref_rejected, beta=0.1):
+    margin = beta * ((logp_chosen - logp_rejected) - (ref_chosen - ref_rejected))
+    return -F.logsigmoid(margin).mean()
+
+# combined objective in one training step
+def total_loss(logits, labels, dpo_terms, lambda_pref=0.5, lambda_safe=0.2, safe_penalty=0.0):
+    loss_sft = sft_loss(logits, labels)
+    loss_pref = dpo_loss(*dpo_terms)
+    return loss_sft + lambda_pref * loss_pref + lambda_safe * safe_penalty
+```
+
+## 5) Example Quality/Latency Trade-off Chart
+
+![Example post-training trade-off chart](/images/blog/posttraining-explained/posttraining-tradeoff-chart.svg)
+
+The chart reflects a common real-world pattern:
+- Helpfulness improves quickly after SFT and preference tuning.
+- Harmlessness improves most after safety tuning.
+- Latency can increase as safety and reranking logic gets added.
+
+## 6) How to Evaluate Post-Training
+
+Use a balanced scorecard instead of one metric:
+
+- **Capability**: instruction-following accuracy, task success rate.
+- **Preference alignment**: win-rate vs baseline in pairwise evals.
+- **Safety**: policy violation rate, jailbreak success rate.
+- **Reliability**: hallucination rate, citation correctness.
+- **Efficiency**: p95 latency, tokens per response, serving cost.
+
+A practical release gate example:
+
+```text
+Ship if:
+- WinRate >= +4.0% vs current production model
+- UnsafeRate <= 0.5%
+- HallucinationRate <= baseline
+- p95 latency <= 2.0s
+```
+
+## 7) Common Mistakes and Fixes
+
+1. **Mistake: over-optimizing one metric**
+   - Fix: keep hard safety/latency guardrails.
+2. **Mistake: noisy preference labels**
+   - Fix: improve rubric quality and annotator agreement checks.
+3. **Mistake: no segment-level analysis**
+   - Fix: evaluate by language, domain, and user intent buckets.
+4. **Mistake: skipping adversarial tests**
+   - Fix: add red-team suites before every release.
+
+## 8) Quick Mental Model
+
+Think of post-training as **behavior engineering for a pretrained brain**:
+- SFT teaches structure,
+- preference tuning teaches taste,
+- safety tuning teaches boundaries,
+- evaluation protects users and product quality.
+
+If you build with this loop, your model gets not only smarter, but also safer and more deployable.


### PR DESCRIPTION
### Motivation
- Provide an easy-to-understand English guide that explains LLM post-training for developers using mixed educational formats (formulas, code, Mermaid diagram, and images). 
- Help engineering teams quickly grasp practical trade-offs and a minimal training recipe for SFT, preference tuning, and safety tuning.

### Description
- Add a new blog article at `src/content/blog/posttraining-explained-for-developers.mdx` that includes concise objectives, core equations, a Mermaid workflow, and a minimal PyTorch-style code example. 
- Add two visual assets under `public/images/blog/posttraining-explained/`: `posttraining-pipeline.svg` and `posttraining-tradeoff-chart.svg` used by the article to illustrate the pipeline and quality/latency trade-offs. 
- This change is content-only and does not modify application logic, data scripts, or runtime behavior.

### Testing
- Ran `npm run build:astro` to validate the site build, which completed successfully. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4321` and rendered the new article page successfully, then captured a full-page screenshot. 
- Generated artifact screenshot at `browser:/tmp/codex_browser_invocations/f1026824546f6462/artifacts/artifacts/posttraining-blog.png` as visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef537cd88832e9a2b288077f3f9fb)