### PR TITLE
blog: add Nano Banana vs Nano Banana 2 prompting guide

### DIFF
--- a/src/content/blog/nanobanana-vs-nanobanana2-prompting-guide.mdx
+++ b/src/content/blog/nanobanana-vs-nanobanana2-prompting-guide.mdx
@@ -1,0 +1,282 @@
+---
+title: "Nano Banana vs Nano Banana 2: Prompting, Capabilities, and Practical Usage"
+description: "A practical, engineering-focused comparison of Nano Banana and Nano Banana 2, including prompt design patterns, quality differences, and how to choose the right model for each task."
+date: 2026-02-27
+tags: ["ai", "prompt-engineering", "llm", "model-comparison", "guide"]
+---
+
+If you are deciding between **Nano Banana** and **Nano Banana 2**, the most useful way to compare them is not by marketing claims, but by workflow outcomes:
+
+- How much prompt detail each model needs
+- How stable outputs are across repeated runs
+- How well each model follows constraints
+- How much post-editing you still need
+
+This guide explains the practical differences, how to prompt each version, and how to build a model-aware workflow that gets reliable results.
+
+## TL;DR
+
+- **Nano Banana** is usually better when you need speed, lower cost, and simple tasks.
+- **Nano Banana 2** is usually better when you need stronger instruction-following, longer-context reasoning, and cleaner first drafts.
+- Your prompting strategy should change by model version. Reusing the exact same prompt often wastes the upgrade.
+
+## 1) What typically changes from v1 to v2
+
+Most model families improve along similar axes between major versions:
+
+| Area | Nano Banana (v1 tendency) | Nano Banana 2 (v2 tendency) |
+|---|---|---|
+| Instruction following | Good for direct requests | Better at multi-constraint prompts |
+| Reasoning depth | Adequate for short chains | Better for layered or conditional logic |
+| Context handling | More likely to miss distant details | Better long-context retention |
+| Style control | Works with explicit examples | More consistent zero-shot style control |
+| Hallucination resistance | Can drift under ambiguity | Usually more grounded with clear context |
+| Latency/cost | Typically lower | Typically higher |
+
+The key idea: **v2 is often less forgiving of vague goals but more powerful when given structure**.
+
+## 2) Why the same prompt can produce very different output
+
+A common mistake is to upgrade the model but keep the same prompt template.
+
+### With Nano Banana (v1)
+
+You often need:
+- Short tasks
+- One objective per prompt
+- Explicit format reminders
+- Fewer nested constraints
+
+### With Nano Banana 2
+
+You can usually do better by adding:
+- Role + audience + purpose
+- Hard constraints (must/must not)
+- Success criteria
+- Self-check instruction before final answer
+
+In practice, v2 gives better results when you provide a **spec**, not just a request.
+
+## 3) Prompt design framework that works for both models
+
+Use this 6-block structure:
+
+1. **Task**: What to produce
+2. **Audience**: Who will read/use it
+3. **Constraints**: Length, tone, forbidden content
+4. **Source truth**: Facts/data to rely on
+5. **Output format**: Exact sections or schema
+6. **Quality bar**: What “good” means
+
+### Reusable template
+
+```text
+You are a {role}.
+
+Task:
+{what to produce}
+
+Audience:
+{target audience}
+
+Constraints:
+- {constraint 1}
+- {constraint 2}
+- {constraint 3}
+
+Source of truth:
+{facts/data/context}
+
+Output format:
+{required structure}
+
+Quality bar:
+- Complete coverage of key points
+- No unsupported claims
+- Clear and actionable language
+
+Before finalizing, verify your output against all constraints.
+```
+
+## 4) Side-by-side prompt examples
+
+## Example A: Blog draft request
+
+### Weak prompt
+
+```text
+Write a blog post about Nano Banana and Nano Banana 2.
+```
+
+### Strong prompt (better for Nano Banana 2)
+
+```text
+Write a 1,500-word technical blog post comparing Nano Banana and Nano Banana 2.
+
+Audience: product engineers and AI application builders.
+Tone: practical, evidence-oriented, no hype.
+
+Required sections:
+1) Capability differences
+2) Prompting strategy differences
+3) Failure modes and mitigation
+4) Cost/latency trade-offs
+5) Decision matrix by use case
+
+Constraints:
+- Use short paragraphs and bullet lists.
+- Include 3 concrete prompt templates.
+- Include an evaluation checklist.
+- Avoid unverifiable benchmark numbers.
+
+Output in Markdown with H2/H3 headings.
+```
+
+Why it works:
+- V1 gets clearer guardrails.
+- V2 can optimize structure and completeness.
+
+## Example B: Classification task
+
+### Prompt for Nano Banana (v1-friendly)
+
+```text
+Classify each support ticket into one category: billing, bug, feature-request, account.
+Return JSON array with fields: ticket_id, category.
+Do not include explanation.
+```
+
+### Prompt for Nano Banana 2 (v2-optimized)
+
+```text
+Classify each support ticket into exactly one category: billing, bug, feature-request, account.
+
+Rules:
+- If payment, invoice, refund, or chargeback appears -> billing
+- If malfunction, error, crash, broken behavior -> bug
+- If user asks for new behavior -> feature-request
+- If login, password, profile, or permissions -> account
+- If ambiguous, choose the most user-impacting category and add "low_confidence": true
+
+Return strict JSON array:
+[{"ticket_id":"...","category":"...","low_confidence":false}]
+
+No prose, no markdown.
+```
+
+Why it works:
+- V2 can enforce nuanced rules while preserving machine-readable output.
+- V1 may still perform well, but usually with more edge-case drift.
+
+## 5) How results differ in real production workflows
+
+You will usually notice differences in these dimensions:
+
+## A) First-pass quality
+- **Nano Banana**: faster draft, more revision cycles.
+- **Nano Banana 2**: slower but closer to publishable first output.
+
+## B) Constraint compliance
+- **Nano Banana**: may violate one of many constraints.
+- **Nano Banana 2**: better at “all constraints at once,” especially with checklists.
+
+## C) Consistency across runs
+- **Nano Banana**: higher variance between runs.
+- **Nano Banana 2**: more stable if prompt structure is fixed.
+
+## D) Tool/API workflows
+- **Nano Banana**: good for simple extraction/formatting.
+- **Nano Banana 2**: better for multi-step tool orchestration and schema-heavy outputs.
+
+## 6) Model-aware prompting strategy
+
+Do not ask “Which model is better?”
+Ask: **“Which model is better for this task shape?”**
+
+Use this routing approach:
+
+- Route to **Nano Banana** when:
+  - low complexity,
+  - high request volume,
+  - strict latency budgets,
+  - disposable or lightly edited output.
+
+- Route to **Nano Banana 2** when:
+  - high factual/format reliability is required,
+  - task has many constraints,
+  - long context must be preserved,
+  - output will be customer-facing or compliance-sensitive.
+
+## 7) Evaluation checklist (use before switching defaults)
+
+Run both models on the same 30–100 representative prompts and score:
+
+- Task completion rate
+- Constraint adherence
+- Factual grounding
+- Output format validity (e.g., JSON parse pass rate)
+- Human edit distance (how much rewriting was needed)
+- Latency (P50/P95)
+- Cost per successful outcome (not just per token)
+
+Pick the model that minimizes **total operational cost**, not raw API price.
+
+## 8) Common mistakes when using Nano Banana 2
+
+1. **Under-specifying the task**
+   - V2 performs best with clear success criteria.
+2. **Overloading a single prompt**
+   - Split planning/execution/formatting into stages when complexity grows.
+3. **Ignoring output contracts**
+   - Always define output schema if another system will consume it.
+4. **No regression set**
+   - Keep a frozen test prompt set to detect quality drift over time.
+
+## 9) Ready-to-use master prompt for high-quality comparison articles
+
+```text
+You are a senior AI systems writer.
+
+Write an in-depth English blog post comparing Nano Banana and Nano Banana 2.
+
+Audience:
+- AI product managers
+- ML engineers
+- developer advocates
+
+Goals:
+- Explain practical capability differences
+- Show how prompting should change between versions
+- Provide repeatable evaluation methodology
+
+Constraints:
+- Be specific and implementation-focused
+- No hype language
+- No unverified numerical claims
+- Use concise paragraphs and bullet points
+
+Required sections:
+1) Executive summary
+2) Capability comparison table
+3) Prompting strategy by model
+4) Three before/after prompt rewrites
+5) Failure modes and mitigation
+6) Decision matrix by use case
+7) Migration playbook from v1 to v2
+
+Output format:
+- Markdown
+- H2/H3 headings
+- Include one checklist and one routing flow in bullets
+
+Before final answer, verify that every required section exists and that all claims are framed as practical tendencies unless evidence is provided.
+```
+
+## Final recommendation
+
+If your current prompts are short and loosely defined, you may not see dramatic gains from Nano Banana 2 immediately. The best results usually come from a **prompt redesign pass** plus a **small evaluation harness**.
+
+In short:
+- Upgrade model **and** upgrade prompt architecture.
+- Measure success by business outcome quality, not just token cost.
+- Keep both models and route dynamically by task complexity.


### PR DESCRIPTION
### Motivation
- Add a practical, engineering-focused English article that explains how `Nano Banana` and `Nano Banana 2` differ in capabilities and how prompting should change between versions.
- Provide concrete prompt templates, evaluation checklists, and a migration/routing strategy to help engineers choose and adopt the right model for different task shapes.

### Description
- Added a new blog post file `src/content/blog/nanobanana-vs-nanobanana2-prompting-guide.mdx` containing a capability comparison table, a 6-block prompt design framework, side-by-side prompt examples, an evaluation checklist, common mistakes, and a ready-to-use master prompt template.
- The post emphasizes practical workflow outcomes (first-pass quality, constraint compliance, consistency, tool/API workflows) and includes routing guidance for when to use v1 vs v2.
- This is a content-only change with no modifications to application code, components, or data scripts.

### Testing
- Ran a full site build using `npm run build`, which completed successfully and generated the new blog route and updated sitemaps.
- No unit or integration tests were changed or required for this content-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1980cf1d4832e8b9d9b898de6ea20)