### PR TITLE
blog: add deep-dive post on Google NanoBanana 2 service opportunities

### DIFF
--- a/src/content/blog/google-nanobanana-2-service-opportunities.mdx
+++ b/src/content/blog/google-nanobanana-2-service-opportunities.mdx
@@ -1,0 +1,339 @@
+---
+title: "Google NanoBanana 2: Where It Can Create New Product Value"
+description: "A practical deep-dive on how a next-generation multimodal NanoBanana model could expand real-world service opportunities, why those opportunities become technically feasible, and how to prompt for reliable outcomes."
+date: 2026-02-27
+tags: ["google", "multimodal-ai", "product-strategy", "llm-ops", "prompt-engineering"]
+---
+
+If you are evaluating **Google NanoBanana 2** for product and service adoption, the key question is not just “Is it better than NanoBanana 1?” but:
+
+> **Which previously fragile use cases now become production-viable due to concrete technical shifts?**
+
+This guide frames NanoBanana 2 through a service-builder lens: where to apply it, why it is now feasible, trade-offs, and practical prompts.
+
+---
+
+## 1) What likely changed from NanoBanana 1 to NanoBanana 2
+
+Even when official benchmark detail is partial, “v2” jumps in multimodal systems usually come from five areas:
+
+1. **Longer and more stable context handling**
+   - Better retrieval over long conversations and documents.
+   - Reduced instruction drift across multi-step flows.
+
+2. **Higher tool-calling reliability**
+   - More deterministic JSON/function call structures.
+   - Better argument grounding from user intent.
+
+3. **Improved multimodal reasoning**
+   - Better OCR + layout + semantic interpretation in one pass.
+   - Better image-to-text and text-to-structured-data conversion.
+
+4. **Latency/cost profile improvements**
+   - Better token efficiency and cache utilization.
+   - Practical for real-time or near-real-time UX.
+
+5. **Safer policy adherence with fewer false positives**
+   - Better compliance classification and redaction quality.
+   - More “usable safety,” not only stricter blocking.
+
+These shifts are exactly what move a feature from “demo-good” to “SLA-capable.”
+
+---
+
+## 2) High-potential service opportunities
+
+### A. AI Support Copilot for Complex Tickets
+
+**What was hard before:** multi-turn enterprise tickets often exceeded context reliability, producing repetitive or hallucinated guidance.
+
+**Why v2 can unlock it technically:**
+- Longer context and better retrieval consistency improve thread memory.
+- Tool-calling improvements allow deterministic pulls from CRM, logs, and runbooks.
+- Safer policy behavior lowers accidental sensitive-data leakage.
+
+**Service pattern:**
+- Input: ticket thread + logs + product docs.
+- Tools: issue tracker API, observability API, internal KB.
+- Output: draft resolution + confidence + escalation route.
+
+**Pros**
+- Faster first-response and resolution times.
+- Better consistency between junior and senior agents.
+
+**Cons**
+- Requires strong grounding architecture (RAG + tool access controls).
+- Bad observability can hide “confidently wrong” outputs.
+
+---
+
+### B. Contract / Policy Review Assistant
+
+**What was hard before:** long legal/policy documents with tables and references caused context loss and citation mistakes.
+
+**Why v2 can unlock it technically:**
+- Better long-context handling preserves clause relationships.
+- Multimodal document understanding improves table and appendix parsing.
+- Structured output reliability enables clause-diff and risk tagging.
+
+**Service pattern:**
+- Input: uploaded policy set and target regulation checklist.
+- Output: compliance matrix, risky clauses, redline suggestions.
+
+**Pros**
+- Significant reduction in first-pass legal review effort.
+- Repeatable auditing format for governance.
+
+**Cons**
+- Must maintain jurisdiction-aware prompt templates.
+- High consequence domain: mandatory human-in-the-loop.
+
+---
+
+### C. Commerce Catalog Intelligence (Image + Text)
+
+**What was hard before:** product ingestion pipelines struggled with mixed-quality images and inconsistent merchant metadata.
+
+**Why v2 can unlock it technically:**
+- Stronger multimodal extraction improves attribute normalization.
+- Better tool-calling supports taxonomy mapping services.
+- Lower latency makes near-real-time ingestion practical.
+
+**Service pattern:**
+- Input: product image, title, merchant description.
+- Output: normalized attributes, confidence scores, category mapping.
+
+**Pros**
+- Better search relevance and faceted navigation.
+- Lower manual catalog QA cost.
+
+**Cons**
+- Edge cases for niche categories remain costly.
+- Needs continuous drift monitoring by category.
+
+---
+
+### D. Personal Learning / Coaching Assistant
+
+**What was hard before:** personalized plans degraded over long interactions and forgot user constraints.
+
+**Why v2 can unlock it technically:**
+- Better long-horizon memory in session context.
+- Better decomposition across planning, feedback, and next-step generation.
+- Improved safety behavior for sensitive mental/health boundaries.
+
+**Service pattern:**
+- Input: goals, history, performance data.
+- Output: adaptive study plan, diagnostics, next 7-day plan.
+
+**Pros**
+- High user retention through personalized loops.
+- Scalable coaching for underserved segments.
+
+**Cons**
+- Risk of over-personalization and dependency.
+- Requires strict guardrails for medical/legal boundaries.
+
+---
+
+### E. Internal BI Analyst Copilot
+
+**What was hard before:** text-to-SQL was brittle in complex schemas and failed silently.
+
+**Why v2 can unlock it technically:**
+- Better tool call schemas and argument fidelity.
+- Improved reasoning over schema docs + metric definitions.
+- Better self-check patterns reduce invalid query attempts.
+
+**Service pattern:**
+- Input: business question + warehouse metadata.
+- Output: SQL draft, assumptions, caveats, chart narrative.
+
+**Pros**
+- Faster insight cycles for non-technical teams.
+- Better metric literacy when responses include assumptions.
+
+**Cons**
+- Semantic layer misalignment can still produce wrong insights.
+- Needs robust permissioning and row-level security.
+
+---
+
+## 3) Why these are now feasible: technical enabling factors
+
+To ship NanoBanana 2 in production, map model improvements to system design:
+
+1. **Context orchestration**
+   - Combine short-term conversation state with retrieval snapshots.
+   - Use hierarchical memory: session summary, task memory, immutable facts.
+
+2. **Deterministic tool layer**
+   - Validate model-generated arguments with JSON schema.
+   - Add retry strategy with tool-specific error typing.
+
+3. **Grounded generation pipeline**
+   - Retrieval first, answer second.
+   - Require citations for high-stakes outputs.
+
+4. **Policy and safety middleware**
+   - Pre-classify request risk.
+   - Redact sensitive entities before model call where possible.
+
+5. **Evaluation + observability loop**
+   - Track factuality, tool success, latency, and user correction rate.
+   - Keep golden task sets and run automated regression checks.
+
+Without these layers, even a stronger v2 model behaves like a smarter demo, not a dependable product backend.
+
+---
+
+## 4) Decision matrix: when to adopt now vs wait
+
+Adopt **now** if:
+- You have a clear bounded workflow (support triage, catalog enrichment, policy checklisting).
+- You can instrument tool success/failure and human corrections.
+- You can maintain domain prompts and eval datasets.
+
+Wait or pilot-only if:
+- Your use case needs near-perfect factual precision with no review step.
+- You lack data governance and permission controls.
+- You cannot afford periodic prompt/evaluation maintenance.
+
+---
+
+## 5) Prompt patterns that work better in production
+
+Below are reusable templates you can adapt.
+
+### Prompt 1: Grounded analyst mode
+
+```text
+You are an enterprise analyst assistant.
+Goal: Answer the user's question using ONLY retrieved sources and tool outputs.
+
+Rules:
+1) If evidence is insufficient, say "insufficient evidence" and ask for a specific missing source.
+2) Separate facts, assumptions, and recommendations.
+3) Provide output as JSON with fields:
+   - answer
+   - evidence[]
+   - assumptions[]
+   - risks[]
+   - next_actions[]
+4) Include source_id for each evidence item.
+
+User question: {{question}}
+Retrieved context: {{retrieved_docs}}
+Tool outputs: {{tool_results}}
+```
+
+**Why it works:** it enforces evidence boundaries and predictable structure for downstream systems.
+
+---
+
+### Prompt 2: Support ticket triage + action plan
+
+```text
+You are Tier-1.5 technical support copilot.
+Classify the ticket, propose likely root causes, and draft next actions.
+
+Return JSON:
+{
+  "severity": "S1|S2|S3|S4",
+  "category": "...",
+  "root_cause_hypotheses": [{"hypothesis":"...","confidence":0-1,"evidence":["..."]}],
+  "required_tools": ["logs.query","status.page","kb.search"],
+  "customer_reply_draft": "...",
+  "escalate": true|false,
+  "escalation_reason": "..."
+}
+
+Constraints:
+- Never invent log values.
+- If confidence < 0.6, default escalate=true.
+- Keep customer reply under 120 words.
+```
+
+**Why it works:** it hardens uncertainty handling and reduces overconfident mis-triage.
+
+---
+
+### Prompt 3: Commerce attribute normalization
+
+```text
+Task: Normalize product attributes for catalog ingestion.
+Input modalities: image + title + merchant_description.
+
+Output schema:
+{
+  "normalized_title": "...",
+  "brand": "...",
+  "category_path": ["...","..."],
+  "attributes": {
+    "color": "...",
+    "material": "...",
+    "size": "...",
+    "gender": "..."
+  },
+  "confidence": 0-1,
+  "needs_human_review": true|false,
+  "review_reason": "..."
+}
+
+Rules:
+- Prefer image evidence over noisy text when conflicting.
+- If confidence < 0.75, set needs_human_review=true.
+- Do not output unknown attributes as guesses.
+```
+
+**Why it works:** it matches multimodal strength while controlling precision/recall trade-offs.
+
+---
+
+### Prompt 4: Policy review with citation discipline
+
+```text
+Role: Policy compliance reviewer.
+Compare Document A against Requirement Set B.
+
+Output markdown sections:
+1) Compliance Summary
+2) Non-Compliant Clauses
+3) Ambiguous Clauses
+4) Suggested Revisions
+5) Evidence Table
+
+Hard constraints:
+- Every claim must include a citation in format [A:section_id] or [B:requirement_id].
+- If no direct citation exists, mark as "uncertain".
+- Keep legal tone neutral and non-advisory.
+```
+
+**Why it works:** citation constraints sharply reduce unsupported claims in high-stakes workflows.
+
+---
+
+## 6) Practical launch plan (30/60/90 days)
+
+**Day 0-30**
+- Pick one narrow workflow with measurable business value.
+- Build baseline prompts, tool schemas, and safety filters.
+- Define offline eval set (at least 100 representative tasks).
+
+**Day 31-60**
+- Run shadow mode in production.
+- Compare v1 vs v2 on factuality, latency, tool success, and manual correction rate.
+- Add escalation rules for low-confidence outputs.
+
+**Day 61-90**
+- Roll out to partial traffic.
+- Implement weekly eval regression and incident review.
+- Expand scope only after KPI stability over 3-4 weeks.
+
+---
+
+## 7) Bottom line
+
+NanoBanana 2’s biggest value is not just higher benchmark scores. It is the **expansion of reliably automatable workflows** when combined with retrieval, tool validation, safety middleware, and evaluation discipline.
+
+If NanoBanana 1 felt “almost there,” NanoBanana 2 can be the version where selected services cross the line from prototype to operating system for real teams.


### PR DESCRIPTION
### Motivation
- Add an English deep-dive post to evaluate where `Google NanoBanana 2` can enable new production services and help operators decide adoption trade-offs. 
- Provide practical, technical reasoning and runnable prompt patterns for product teams, not just marketing claims.

### Description
- Added a new blog file at `src/content/blog/google-nanobanana-2-service-opportunities.mdx` that outlines likely v1->v2 capability deltas, high-potential service use cases (support copilot, policy review, commerce catalog intelligence, coaching, BI copilot), and pros/cons per case. 
- Included system-level recommendations (context orchestration, deterministic tool layer, grounded generation, safety middleware, observability) plus production-ready prompt templates and a 30/60/90 rollout plan. 
- Content-only change with metadata (`title`, `description`, `date`, `tags`) and no code or data-pipeline modifications, and a rendered blog page screenshot was captured during validation.

### Testing
- Ran `npm run build` which completed successfully and produced the static site and split sitemaps (build completed and sitemap generation finished). 
- No unit or integration tests were added or modified for this content-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1999f047c832e99475df7009b58c9)