### PR TITLE
blog: add three skill deep-dive posts

### DIFF
--- a/src/content/blog/humanizer-skill-guide.mdx
+++ b/src/content/blog/humanizer-skill-guide.mdx
@@ -1,0 +1,203 @@
+---
+title: "Humanizer: Why Clean AI Writing Still Sounds Wrong"
+description: "A detailed guide to the Humanizer skill, the writing patterns it catches, why AI prose often feels off, and how to use the skill without flattening your voice."
+date: 2026-03-09
+tags: ["skills", "writing", "ai", "editing", "content"]
+---
+
+AI can write fast. That part is over.
+
+The problem now is that a lot of AI writing still sounds like it was assembled by a committee that was trying very hard not to offend a toaster.
+
+It is polished. It is grammatical. It is often useful. And yet something feels off.
+
+That "off" feeling is exactly why the [Humanizer](https://github.com/blader/humanizer) skill exists.
+
+## The Problem Humanizer Is Actually Solving
+
+Bad AI writing is easy to spot. Everybody knows the examples.
+
+- empty hype,
+- padded conclusions,
+- fake authority,
+- sterile enthusiasm,
+- and sentences that keep implying significance instead of saying anything concrete.
+
+But the harder problem is *good-looking bad writing*. The kind that reads smoothly at first and still leaves no real impression. The kind that sounds capable and vague at the same time.
+
+Humanizer is built for that second problem.
+
+The repository README says the skill is based on Wikipedia's guide to [Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), and that matters. It means the skill is not just chasing vibes. It is grounded in a documented set of recurring patterns people keep seeing in machine-generated text.
+
+## Why Readers Notice AI Writing So Quickly
+
+People do not usually detect AI writing because they ran a classifier in their head.
+
+They notice because the prose keeps doing things humans rarely do on purpose:
+
+- inflating significance,
+- leaning on abstract words instead of specifics,
+- forcing tidy lists of three,
+- overusing transitions like `Additionally`,
+- and closing with generic optimism that nobody actually earned.
+
+The text is not wrong. It is evasive.
+
+## The Most Useful Idea in the Skill
+
+Humanizer does not just say, "Make it more natural."
+
+It breaks the problem into patterns.
+
+That is important because vague editing instructions lead to vague editing results. If you want better prose, you need to know what the model should cut, what it should replace, and what it should preserve.
+
+According to the README and skill guidance, Humanizer looks for recurring issues such as:
+
+- significance inflation,
+- promotional language,
+- vague attributions,
+- AI-flavored vocabulary,
+- copula avoidance,
+- rule-of-three overuse,
+- em dash overuse,
+- filler phrases,
+- and chatbot residue like "I hope this helps."
+
+That list is more practical than it sounds. It gives you a repeatable editing checklist.
+
+## Mermaid: Why AI Prose Feels Artificial
+
+```mermaid
+flowchart TD
+  A[Model predicts likely next phrase] --> B[Chooses safe general wording]
+  B --> C[Adds abstract emphasis]
+  C --> D[Uses polished transitions and filler]
+  D --> E[Produces fluent but generic prose]
+  E --> F[Reader senses no real author behind it]
+```
+
+That final step is the real issue. Readers want a mind on the page, not just a sentence generator.
+
+## What Humanizer Gets Right
+
+The best part of the project is that it treats human writing as more than the absence of obvious AI markers.
+
+The local skill guidance goes further than the README and makes a sharp point: a cleaned-up draft can still be dead on arrival if it has no voice. That is exactly right. Mechanical cleanup is not enough. Writing needs rhythm, point of view, and sometimes a little friction.
+
+In other words, this skill is not only about removing bad patterns. It is about putting a person back into the draft.
+
+## Before and After: What the Skill Is Fixing
+
+### AI-sounding version
+
+```txt
+AI coding assistants stand as a pivotal force in the evolving landscape
+of software development, showcasing their transformative potential across
+teams, workflows, and outcomes.
+```
+
+### Better version
+
+```txt
+AI coding assistants are useful for the boring parts of the job.
+They can save time on setup and boilerplate. They can also make you less
+careful if you stop reviewing what they suggest.
+```
+
+The second version is not fancy. That is why it works.
+
+## Chart: The Patterns That Usually Hurt Most
+
+```mermaid
+pie title Common AI Writing Problems Humanizer Targets
+  "Vague abstraction" : 25
+  "Promotional language" : 20
+  "Formulaic structure" : 20
+  "Chatbot filler and hedging" : 15
+  "Artificial rhythm and vocabulary" : 20
+```
+
+## How to Use Humanizer Without Wrecking the Draft
+
+This matters: not every draft should be pushed toward the same tone.
+
+If you run "humanization" as a blunt operation, you can strip away useful structure or flatten a deliberate formal voice. The goal is not to make every piece sound casual. The goal is to make the writing sound authored.
+
+Use the skill well like this:
+
+1. Start with a draft that already knows what it is trying to say.
+2. Humanize after structure and facts are stable.
+3. Preserve the intended voice: technical, essayistic, academic, direct, or conversational.
+4. Ask for pattern-based cleanup, not "make this sound better."
+5. Do one final pass for specifics, rhythm, and conviction.
+
+## Code: A Sensible Workflow in Claude Code
+
+```txt
+/humanizer
+
+Please humanize the draft below.
+Keep it in plain English.
+Do not make it casual for the sake of casualness.
+Remove AI patterns, but preserve the technical tone and the author's point of view.
+After the rewrite, briefly list any remaining phrases that still sound machine-generated.
+```
+
+That last sentence matters because the README notes a final audit pass. It is a smart move. A first rewrite often removes the loud signals and leaves the subtler ones behind.
+
+## What Good Humanized Writing Actually Looks Like
+
+It is usually more concrete.
+
+It uses simpler verbs.
+
+It stops pretending every paragraph is announcing a civilization-scale turning point.
+
+And it lets a claim be modest when modesty is the honest shape of the claim.
+
+## A Quick Editing Checklist
+
+When I read AI-heavy copy, these are the questions I reach for first:
+
+| Check | Bad sign | Better direction |
+|---|---|---|
+| Is the sentence saying something concrete? | Abstract nouns are doing all the work | Add facts, examples, or direct claims |
+| Does it sound inflated? | Everything is pivotal, transformative, or vital | Scale the language to the evidence |
+| Is the attribution real? | "Experts say" with no source | Name the source or cut the line |
+| Is the rhythm too even? | Every sentence has the same polished cadence | Mix shorter and longer beats |
+| Is there a real point of view? | The prose avoids any stance | Let the author sound like a person |
+
+## Where Humanizer Helps the Most
+
+This skill is especially strong for:
+
+- blog posts generated from rough AI drafts,
+- marketing copy that sounds suspiciously eager,
+- technical explanations that became too polished and too empty,
+- and editorial cleanup before publishing.
+
+It is also useful as a teaching tool. Once you see the patterns enough times, you start catching them in your own prompts and drafts before they spread.
+
+## Where It Will Not Save You
+
+Humanizer can improve language. It cannot invent substance.
+
+If the draft has weak ideas, fuzzy sourcing, or no real argument, you will still need an actual editorial pass. Cleaner nonsense is still nonsense.
+
+That is worth saying because some teams try to use "humanization" as the final polish on text that was never strong enough to publish in the first place.
+
+## The Deeper Lesson
+
+What makes AI writing feel artificial is not just wording. It is distance.
+
+The draft feels like nobody has skin in it. Nobody is willing to say, "This part is shaky," or "This is the trade-off that matters," or "I do not buy the hype here."
+
+Human writing leaves fingerprints. AI writing often wipes the surface clean.
+
+The Humanizer skill is useful because it pushes in the opposite direction. It tells the model to stop smoothing everything out and start sounding like somebody meant the words.
+
+## Final Takeaway
+
+If you publish a lot of AI-assisted writing, Humanizer is not a cosmetic tool. It is quality control.
+
+Use it after the facts are solid and before the piece goes live. Let it remove the obvious tells. Then do the part no skill can fully automate: make sure the draft still has a mind, a voice, and a reason to exist.

--- a/src/content/blog/installing-codex-superpowers-guide.mdx
+++ b/src/content/blog/installing-codex-superpowers-guide.mdx
@@ -1,0 +1,219 @@
+---
+title: "Installing Superpowers in Codex: Why Skills Matter More Than a Bigger Prompt"
+description: "A practical guide to installing Superpowers for Codex, what native skill discovery changes, and why reusable skills beat stuffing every rule into one giant prompt."
+date: 2026-03-09
+tags: ["skills", "codex", "automation", "productivity", "setup"]
+---
+
+There is a common mistake people make when working with coding agents.
+
+They keep adding more instructions to the main prompt.
+
+At first it feels smart. You add workflow rules, code review rules, debugging rules, writing rules, Git rules, naming rules, testing rules. Soon your setup looks serious. It also starts to feel heavy, repetitive, and strangely unreliable.
+
+That is where skills start to matter.
+
+The installation guide in [`obra/superpowers`](https://github.com/obra/superpowers/blob/main/.codex/INSTALL.md) is short, but the idea behind it is much bigger than the commands themselves.
+
+## What Superpowers Is Solving
+
+Superpowers brings reusable skills into Codex through native skill discovery.
+
+The installation guide describes a straightforward setup:
+
+1. Clone the `superpowers` repository into `~/.codex/superpowers`.
+2. Create a symlink from `~/.agents/skills/superpowers` to that skills directory.
+3. Restart Codex so the skills are discovered.
+
+That is the whole mechanical setup. The interesting part is *why* you would want this in the first place.
+
+## Why Bigger Prompts Stop Scaling
+
+When everything lives in one giant instruction file, three problems show up fast:
+
+| Problem | What happens | Why it gets worse over time |
+|---|---|---|
+| Prompt bloat | Every task carries every rule | You pay context cost for instructions you do not need |
+| Weak routing | The model must infer which rules matter right now | Good rules are ignored or misapplied |
+| Maintenance pain | Updating one workflow means editing global guidance | The system becomes brittle and stale |
+
+Skills fix this by turning reusable workflows into things the agent can discover and load when relevant.
+
+That is a much cleaner model.
+
+## Mermaid: Monolithic Prompt vs Skill-Based Workflow
+
+```mermaid
+flowchart LR
+  A[One giant prompt] --> B[All rules loaded all the time]
+  B --> C[High context cost]
+  B --> D[Weak task-specific focus]
+  E[Skill-based setup] --> F[Discover relevant skill]
+  F --> G[Load only needed workflow]
+  G --> H[Lower noise and better routing]
+```
+
+This is not only about convenience. It is about operational clarity.
+
+## The Install Guide, Translated Into Plain English
+
+The official install steps are simple:
+
+```bash
+git clone https://github.com/obra/superpowers.git ~/.codex/superpowers
+mkdir -p ~/.agents/skills
+ln -s ~/.codex/superpowers/skills ~/.agents/skills/superpowers
+```
+
+Then restart Codex.
+
+That symlink is the key detail. It means Codex does not need a custom bootstrap hack to find the skills. It can discover them through the normal skills path.
+
+The guide also explains migration for older setups. If you previously used a bootstrap block in `~/.codex/AGENTS.md`, you should remove it after switching to native discovery.
+
+That sounds small. It is not. Removing old bootstrap logic usually means fewer hidden dependencies, fewer surprises, and less setup debt.
+
+## Why Skills Are Better Than Repetition
+
+Say you keep telling your agent versions of the same thing:
+
+- plan before complex work,
+- use debugging discipline on bugs,
+- verify before saying something is done,
+- ask for design before building frontend features,
+- request code review at the end.
+
+Those are not one-off reminders. They are workflows.
+
+A workflow deserves a home of its own.
+
+That is what skills are for.
+
+## Code: Verify the Install
+
+The guide suggests a simple check:
+
+```bash
+ls -la ~/.agents/skills/superpowers
+```
+
+You should see a symlink or junction pointing to the cloned repository.
+
+I would also check the target directly:
+
+```bash
+ls -la ~/.codex/superpowers/skills
+```
+
+If both look right and Codex has been restarted, the discovery path is usually in good shape.
+
+## Chart: Why Teams Adopt Skill-Based Setups
+
+```mermaid
+pie title Why Skill-Based Agent Setups Work Better
+  "Reusable workflows" : 30
+  "Lower context overhead" : 25
+  "Better task routing" : 25
+  "Easier maintenance and updates" : 20
+```
+
+## How to Use Superpowers Well After Installing It
+
+Installing the repo is the easy part. The real payoff comes from how you use the skills afterward.
+
+The productive pattern looks like this:
+
+1. Let process skills shape the workflow first.
+2. Use implementation skills only after the process is clear.
+3. Keep project-specific rules in project files.
+4. Keep reusable methods in skills.
+5. Update the skill source once, not the same prompt in ten places.
+
+This separation matters.
+
+Project instructions answer, "What matters in this repo?"
+
+Skills answer, "How should this class of work be done?"
+
+Mixing those two layers carelessly is how agent setups become messy.
+
+## A Good Mental Model
+
+Think of your setup in three layers:
+
+```mermaid
+flowchart TD
+  A[Global agent behavior] --> B[Reusable skills]
+  B --> C[Project-specific instructions]
+  C --> D[Task-specific prompt]
+```
+
+Each layer has a job:
+
+- global behavior sets baseline safety and tool rules,
+- skills provide reusable workflows,
+- project instructions define repo context,
+- and the task prompt describes the immediate goal.
+
+When those layers are clean, the agent behaves more predictably.
+
+## When Superpowers Feels Most Valuable
+
+You feel the value fastest if you do any of the following:
+
+- switch between debugging, frontend work, writing, and code review often,
+- work across multiple repositories,
+- collaborate with other people who need the same workflows,
+- or keep discovering that your "perfect prompt" keeps turning into an instruction landfill.
+
+If that last line feels familiar, skills are probably the missing abstraction.
+
+## Common Mistakes After Installation
+
+The install itself is simple, but the usage pattern still goes wrong in familiar ways:
+
+| Mistake | Result |
+|---|---|
+| Treating skills like optional decoration | The agent falls back to generic behavior |
+| Keeping old bootstrap logic around | Confusing setup and duplicated instructions |
+| Stuffing repo-specific details into global skills | Skills become less reusable |
+| Installing skills but never structuring prompts clearly | Better tools, same messy outcomes |
+
+The fix is mostly discipline. Skills help when you let them carry real workflow weight.
+
+## Updating and Uninstalling
+
+The guide also keeps maintenance minimal:
+
+```bash
+cd ~/.codex/superpowers && git pull
+```
+
+Because the setup uses a symlink, updates flow through immediately after the repo changes.
+
+To uninstall:
+
+```bash
+rm ~/.agents/skills/superpowers
+```
+
+Optionally remove the clone too:
+
+```bash
+rm -rf ~/.codex/superpowers
+```
+
+That is a clean lifecycle. No complicated installer state. No mystery bootstrap scripts hanging around years later.
+
+## Final Takeaway
+
+The install guide is short because the commands are simple. The payoff is not.
+
+Superpowers matters because it nudges you toward a better way of working with coding agents:
+
+- smaller prompts,
+- clearer workflow routing,
+- reusable methods,
+- and less dependence on one bloated master instruction block.
+
+If you are serious about agentic development, that shift is worth more than another long prompt full of rules the model may or may not use at the right moment.

--- a/src/content/blog/ui-ux-pro-max-skill-guide.mdx
+++ b/src/content/blog/ui-ux-pro-max-skill-guide.mdx
@@ -1,0 +1,247 @@
+---
+title: "UI UX Pro Max: Why AI Needs Design Taste, Not Just Code Generation"
+description: "A practical guide to the UI UX Pro Max skill, why it matters, how its design-system workflow works, and how to use it to get better interfaces from AI."
+date: 2026-03-09
+tags: ["skills", "ui-ux", "design", "ai", "codex"]
+---
+
+Most AI coding tools can produce UI code.
+
+That is not the same thing as producing good UI.
+
+This gap matters more than people admit. A model can generate a hero section, a dashboard, or a pricing card in seconds, but speed does not solve the hard part. The hard part is taste. The hard part is choosing a visual direction that fits the product, the audience, the device, the brand, and the conversion goal.
+
+That is the problem [UI UX Pro Max](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill) is trying to solve.
+
+![UI UX Pro Max screenshot](https://raw.githubusercontent.com/nextlevelbuilder/ui-ux-pro-max-skill/main/screenshots/website.png)
+
+## The Real Problem: AI Can Build Layouts Without Building Judgment
+
+Here is the failure mode most teams hit:
+
+1. They ask an AI to build a landing page.
+2. The AI gives them something polished enough to look finished.
+3. The result is still generic, off-brand, or awkward to use.
+
+It happens because most prompts describe the *page*, not the *design system behind the page*.
+
+If you say, "Build a fintech dashboard," you will usually get a dashboard. But should it feel dense or calm? Dark or light? Executive or operator-focused? Conservative or high-energy? Should charts lead the page, or should risk controls lead the page? What typography carries trust instead of startup theater?
+
+Those are design decisions. They cannot be fixed by sprinkling more Tailwind classes on top.
+
+## What UI UX Pro Max Actually Adds
+
+According to the repository README, the skill packages a large UI/UX knowledge base around:
+
+- dozens of UI styles,
+- industry-specific color palettes,
+- font pairings,
+- chart recommendations,
+- UX and accessibility rules,
+- and a reasoning layer that turns product context into a concrete design-system recommendation.
+
+The useful idea is simple: before the model starts writing JSX, Astro, or Tailwind, it should decide what kind of interface it is building.
+
+## Why That Matters More Than Another "Beautiful UI" Prompt
+
+Prompt-only UI generation tends to fail in four predictable ways:
+
+| Failure | What it looks like | Why it hurts |
+|---|---|---|
+| Style drift | Every section looks like a different template | The product feels untrustworthy |
+| Trend bias | Purple gradients everywhere, regardless of use case | The interface signals "AI demo" instead of product clarity |
+| Accessibility debt | Weak contrast, tiny hit targets, vague focus states | The site looks polished and still fails users |
+| No product fit | Same design language for banking, wellness, and dev tools | The UI misses the mood the business actually needs |
+
+UI UX Pro Max tries to reduce that by front-loading design choices.
+
+## The Core Mental Model
+
+Think of the skill as a design brief generator for AI.
+
+Instead of asking the model to improvise everything from scratch, you ask it to derive:
+
+- a page pattern,
+- a visual style,
+- a color system,
+- a typography direction,
+- interaction rules,
+- anti-patterns to avoid,
+- and stack-specific implementation guidance.
+
+That changes the workflow from "generate a page" to "generate a system, then generate a page from the system."
+
+## Mermaid: The Better Workflow
+
+```mermaid
+flowchart TD
+  A[User request] --> B[Identify product type and audience]
+  B --> C[Generate design system]
+  C --> D[Choose pattern, style, colors, type, effects]
+  D --> E[Apply UX and accessibility rules]
+  E --> F[Generate implementation code]
+  F --> G[Review against anti-patterns]
+```
+
+That extra design-system step is where most of the value lives.
+
+## What the Repository Suggests
+
+The project README highlights a few implementation details that are worth paying attention to:
+
+- It supports many stacks and assistants, not just one.
+- It includes a CLI installation path through `uipro-cli`.
+- It exposes a direct search workflow for style, typography, charts, landing patterns, and stack guidance.
+- It supports persisted design systems through a `design-system/MASTER.md` pattern plus page-specific overrides.
+
+That last part is the most strategic feature in the whole project.
+
+## The Best Feature: Persistent Design Systems
+
+Most AI-generated UI work falls apart over time, not on day one.
+
+The first page might look good. The second page looks related. By the fifth page, the product has three button radii, two card shadows, four spacing rhythms, and a typography stack that feels like it was assembled during a power outage.
+
+Persistent design-system files fix that.
+
+The README describes a workflow where you can store global rules in `design-system/MASTER.md` and page-level deviations in `design-system/pages/<page>.md`. That gives the model a stable source of truth instead of asking it to remember design consistency from chat history alone.
+
+## Code: A Practical Starting Point
+
+```bash
+# Install the CLI
+npm install -g uipro-cli
+
+# Initialize the skill for Codex CLI
+uipro init --ai codex
+
+# Generate a design system directly
+python3 .codex/skills/ui-ux-pro-max/scripts/search.py \
+  "B2B fintech analytics dashboard" \
+  --design-system \
+  --persist \
+  -p "Northstar Risk"
+```
+
+Once you have that, your prompt quality changes immediately:
+
+```txt
+Read design-system/MASTER.md first.
+Build the overview dashboard page for a B2B fintech analytics product.
+Keep the interface operator-focused, calm, and high-trust.
+Prefer light mode, dense information hierarchy, clear error states,
+and restrained motion.
+```
+
+That is a much stronger input than "make a nice dashboard."
+
+## Before and After: Prompt Quality
+
+### Weak prompt
+
+```txt
+Build a modern dashboard for my fintech app.
+```
+
+### Better prompt
+
+```txt
+Use the persisted design system for this project.
+Prioritize trust, legibility, and dense but calm information layout.
+Avoid neon accents, glass-heavy panels, and decorative motion.
+Primary users are finance operators reviewing risk and settlement status.
+Build the dashboard in Astro with React islands and Tailwind utilities.
+```
+
+The second prompt gives the AI a point of view. That is what good design needs.
+
+## Chart: Where the Skill Helps Most
+
+```mermaid
+pie title Where UI UX Pro Max Creates the Most Leverage
+  "Design-system alignment" : 35
+  "Reducing generic AI aesthetics" : 25
+  "Accessibility and UX guardrails" : 20
+  "Stack-specific execution help" : 20
+```
+
+## How to Use It Well
+
+If you install the skill and stop at "make this prettier," you will miss most of its value.
+
+Use it well like this:
+
+1. Start with product context, not component requests.
+2. Generate the design system before asking for code.
+3. Persist the design system when the project has more than one page.
+4. Use page overrides only when a page truly needs a different tone.
+5. Re-run the design-system step when the audience or product category changes.
+
+## What to Tell the Model Up Front
+
+The skill gets better when your request includes:
+
+- product type,
+- target audience,
+- trust level or brand tone,
+- primary goal of the page,
+- preferred stack,
+- and constraints such as accessibility, density, or motion limits.
+
+Good:
+
+```txt
+Design a healthcare appointment dashboard for clinic staff.
+Light theme. Fast scanning. High accessibility.
+Use Astro plus React islands. Avoid decorative gradients.
+```
+
+Bad:
+
+```txt
+Make a cool healthcare dashboard.
+```
+
+The second prompt almost guarantees a shallow result.
+
+## A Useful Way to Think About Style
+
+A lot of AI-generated UI looks impressive in screenshots and weak in products.
+
+That is because screenshots reward novelty, while products reward repeatable clarity.
+
+UI UX Pro Max is useful when you need the model to optimize for the second thing. It gives the AI a structured way to pick a design language that can survive real navigation, real forms, real error states, and real users.
+
+## Who Should Use It
+
+This skill is especially useful for:
+
+- solo builders who do not have a designer on every iteration,
+- engineers who can implement quickly but want stronger design direction,
+- teams using AI to scaffold interfaces across multiple pages,
+- and anyone who is tired of getting "AI purple gradient SaaS" no matter what they asked for.
+
+## Where It Can Still Go Wrong
+
+The skill improves design decisions, but it does not replace product judgment.
+
+You still need to review:
+
+- whether the chosen style fits your actual brand,
+- whether the generated hierarchy matches task importance,
+- whether data-dense interfaces are truly readable,
+- and whether the final code respects the rules it was given.
+
+In other words, this is not autopilot. It is better instrumentation.
+
+## Final Takeaway
+
+UI generation is cheap now. Design coherence is not.
+
+That is why a skill like UI UX Pro Max matters. It gives AI something most code-generation workflows are missing: a way to reason about visual systems before touching the code.
+
+If you use AI for frontend work, this is the shift worth making:
+
+Stop asking for pages.
+
+Start asking for design systems, constraints, and product fit. The page quality goes up because the decisions behind the page stop being random.


### PR DESCRIPTION
## What changed
- added a detailed English blog post about UI UX Pro Max and how to use design-system generation effectively
- added a detailed English blog post about Humanizer and the specific writing patterns it helps remove
- added a detailed English blog post about installing Superpowers in Codex and why skill-based workflows scale better than larger prompts
- included visual aids in the posts with Mermaid diagrams, comparison tables, and practical command/prompt examples

## Why
The user requested three detailed, publish-ready markdown blog posts based on the referenced skill repositories/docs, written to make the value of each skill clear and actionable.

## Testing
- `npm run build`

## Screenshots / GIFs
- not applicable; content-only change

## Notes
- content is source-grounded against the referenced repositories and install doc
- no app logic or data scripts were changed
